### PR TITLE
Full ingest of seqcol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,12 @@
 			<artifactId>postgresql</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>io.github.erdtman</groupId>
+			<artifactId>java-json-canonicalization</artifactId>
+			<version>1.1</version>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
@@ -1,0 +1,47 @@
+package uk.ac.ebi.eva.evaseqcol.controller.admin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
+import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColException;
+import uk.ac.ebi.eva.evaseqcol.service.SeqColService;
+
+import java.io.IOException;
+
+@RequestMapping("/collection/admin")
+@RestController
+public class AdminController {
+
+    private SeqColService seqColService;
+
+    @Autowired
+    public AdminController(SeqColService seqColService) {
+        this.seqColService = seqColService;
+    }
+
+    /**
+     * Naming convention should be either ENA, GENBANK or UCSC */
+    @PutMapping(value = "/seqcols/{asmAccession}/{namingConvention}")
+    public ResponseEntity<?> fetchAndInsertSeqColByAssemblyAccessionAndNamingConvention(
+            @PathVariable String asmAccession, @PathVariable String namingConvention) {
+        // TODO: REMOVE THE NAMING CONVENTION PATH VARIABLE AND MAKE IT GENERIC
+        try {
+            seqColService.fetchAndInsertSeqColByAssemblyAccession(
+                    asmAccession, SeqColEntity.NamingConvention.valueOf(namingConvention));
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+        }
+        catch (IOException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (DuplicateSeqColException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.OK);
+        }
+        return new ResponseEntity<>("Successfully inserted seqCol for assemblyAccession " + asmAccession, HttpStatus.OK);
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/authentication/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/authentication/SecurityConfiguration.java
@@ -1,0 +1,21 @@
+package uk.ac.ebi.eva.evaseqcol.controller.authentication;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+            .authorizeRequests()
+            .antMatchers("/collection/**").permitAll()
+            .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+    }
+
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/authentication/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/authentication/SecurityConfiguration.java
@@ -15,6 +15,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         http.csrf().disable()
             .authorizeRequests()
             .antMatchers("/collection/**").permitAll()
+            .antMatchers("/collection/admin/**").permitAll()
             .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
     }
 

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
@@ -1,0 +1,12 @@
+package uk.ac.ebi.eva.evaseqcol.controller.seqcol;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/collection")
+@RestController
+public class SeqColController {
+
+
+
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
@@ -1,12 +1,54 @@
 package uk.ac.ebi.eva.evaseqcol.controller.seqcol;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/collection")
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
+import uk.ac.ebi.eva.evaseqcol.service.SeqColService;
+
+import java.util.Optional;
+
 @RestController
+@RequestMapping("/collection")
 public class SeqColController {
 
+    private SeqColService seqColService;
 
+    @Autowired
+    public SeqColController(SeqColService seqColService) {
+        this.seqColService = seqColService;
+    }
+
+    @GetMapping(value = "/{digest}")
+    public ResponseEntity<SeqColEntity> getSeqColByDigestAndLevel(
+            @PathVariable String digest, @RequestParam(required = false) String level) {
+        if (level == null) {
+            level = "none";
+        }
+        switch (level) {
+            case "1":
+            case "none":
+                Optional<SeqColLevelOneEntity> levelOneEntity = (Optional<SeqColLevelOneEntity>) seqColService.getSeqColByDigestAndLevel(digest, 1);
+                if (levelOneEntity.isPresent()) {
+                    return ResponseEntity.ok(levelOneEntity.get());
+                }
+                break;
+            case "2":
+                Optional<SeqColLevelTwoEntity> levelTwoEntity = (Optional<SeqColLevelTwoEntity>) seqColService.getSeqColByDigestAndLevel(digest, 2);
+                if (levelTwoEntity.isPresent()) {
+                    return ResponseEntity.ok(levelTwoEntity.get());
+                }
+                break;
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBIAssemblySequenceDataSource.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBIAssemblySequenceDataSource.java
@@ -44,7 +44,7 @@ public class NCBIAssemblySequenceDataSource implements AssemblySequencesDataSour
     }
 
     @Override
-    public Optional<AssemblySequenceEntity> getAssemblySequencesByAccession(String accession) throws IOException, IllegalArgumentException, NoSuchAlgorithmException {
+    public Optional<AssemblySequenceEntity> getAssemblySequencesByAccession(String accession) throws IOException, IllegalArgumentException {
         NCBIBrowser ncbiBrowser = factory.build();
         ncbiBrowser.connect();
         GzipCompress gzipCompress = new GzipCompress();

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSource.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSource.java
@@ -1,0 +1,188 @@
+package uk.ac.ebi.eva.evaseqcol.datasource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import uk.ac.ebi.eva.evaseqcol.entities.AssemblyEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
+import uk.ac.ebi.eva.evaseqcol.refget.DigestCalculator;
+import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
+import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+
+@Repository("NCBISeqColDataSource")
+public class NCBISeqColDataSource implements SeqColDataSource{
+
+    private final Logger logger = LoggerFactory.getLogger(NCBISeqColDataSource.class);
+
+    private final NCBIAssemblyDataSource assemblyDataSource;
+    private final NCBIAssemblySequenceDataSource assemblySequenceDataSource;
+    private DigestCalculator digestCalculator = new DigestCalculator();
+
+    @Autowired
+    public NCBISeqColDataSource(NCBIAssemblyDataSource assemblyDataSource,
+                                NCBIAssemblySequenceDataSource assemblySequenceDataSource
+                                ) {
+        this.assemblyDataSource = assemblyDataSource;
+        this.assemblySequenceDataSource = assemblySequenceDataSource;
+    }
+
+    /**
+     * Download both the Assembly Report and the Sequences FASTA file for the given accession
+     * and return the seqCol extended data list: names, lengths and sequences */
+    public Optional<List<SeqColExtendedDataEntity>> getSeqColExtendedDataListByAccession(
+            String accession, SeqColEntity.NamingConvention namingConvention) throws IOException {
+        Optional<AssemblyEntity> assemblyEntity = assemblyDataSource.getAssemblyByAccession(accession);
+        if (!assemblyEntity.isPresent()) {
+            logger.error("Could not fetch Assembly Report from NCBI for accession: " + accession);
+            return Optional.empty();
+        } else if (!(assemblyEntity.get().getChromosomes() != null && assemblyEntity.get().getChromosomes().size() > 0)) {
+            logger.error("No chromosome in assembly " + accession + ". Aborting");
+            return Optional.empty();
+        }
+        Optional<AssemblySequenceEntity> sequenceEntity = assemblySequenceDataSource.getAssemblySequencesByAccession(accession);
+        if (!sequenceEntity.isPresent()) {
+            logger.error("Could not fetch Sequences FASTA file from NCBI for accession: " + accession);
+            return Optional.empty();
+        }
+        List<SeqColExtendedDataEntity> extendedDataEntities = constructExtendedSeqColDataList(
+                assemblyEntity.get(), sequenceEntity.get(), namingConvention, accession);
+        return Optional.of(extendedDataEntities);
+    }
+
+    @Override
+    /**
+     * Download both the Assembly Report and the Sequences FASTA file for the given accession
+     * and return the seqCol Level one entity for the given naming convention*/
+    public Optional<SeqColLevelOneEntity> getSeqColL1ByAssemblyAccession(
+            String accession, SeqColEntity.NamingConvention namingConvention) throws IOException {
+        Optional<AssemblyEntity> assemblyEntity = assemblyDataSource.getAssemblyByAccession(accession);
+        if (!assemblyEntity.isPresent()) {
+            logger.error("Could not fetch Assembly Report from NCBI for accession: " + accession);
+            return Optional.empty();
+        }
+        Optional<AssemblySequenceEntity> sequenceEntity = assemblySequenceDataSource.getAssemblySequencesByAccession(accession);
+        if (!sequenceEntity.isPresent()) {
+            logger.error("Could not fetch Sequences FASTA file from NCBI for accession: " + accession);
+            return Optional.empty();
+        }
+        List<SeqColExtendedDataEntity> extendedDataEntities = constructExtendedSeqColDataList(
+                assemblyEntity.get(), sequenceEntity.get(), namingConvention, accession);
+        SeqColLevelOneEntity levelOneEntity = constructSeqColLevelOne(extendedDataEntities, namingConvention);
+        return Optional.of(levelOneEntity);
+    }
+
+    /**
+     * Construct a seqCol level 1 entity out of three seqCol level 2 entities that
+     * hold names, lengths and sequences objects*/
+    public SeqColLevelOneEntity constructSeqColLevelOne(List<SeqColExtendedDataEntity> extendedDataEntities,
+                                                 SeqColEntity.NamingConvention convention) throws IOException {
+        SeqColLevelOneEntity levelOneEntity = new SeqColLevelOneEntity();
+        JSONLevelOne jsonLevelOne = new JSONLevelOne();
+        for (SeqColExtendedDataEntity dataEntity: extendedDataEntities) {
+            switch (dataEntity.getAttributeType()) {
+                case lengths:
+                    jsonLevelOne.setLengths(dataEntity.getDigest());
+                    break;
+                case names:
+                    jsonLevelOne.setNames(dataEntity.getDigest());
+                    break;
+                case sequences:
+                    jsonLevelOne.setSequences(dataEntity.getDigest());
+                    break;
+            }
+        }
+        levelOneEntity.setObject(jsonLevelOne);
+        String digest0 = digestCalculator.generateDigest(levelOneEntity.toString());
+        levelOneEntity.setDigest(digest0);
+        levelOneEntity.setNamingConvention(convention);
+        return levelOneEntity;
+    }
+
+    /**
+     * Return the 3 extended data objects (names, lengths and sequences) of the given naming convention*/
+    public List<SeqColExtendedDataEntity> constructExtendedSeqColDataList(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
+                                                                   SeqColEntity.NamingConvention convention, String assemblyAccession) throws IOException {
+        // Sorting the chromosomes' list (assemblyEntity) and the sequences' list (sequencesEntity) in the same order
+        return Arrays.asList(
+                constructSeqColSequencesObject(assemblySequenceEntity),
+                constructSeqColNamesObject(assemblyEntity, convention),
+                constructSeqColLengthsObject(assemblyEntity)
+        );
+    }
+
+    /**
+     * Return the seqCol names array object*/
+    public SeqColExtendedDataEntity constructSeqColNamesObject(AssemblyEntity assemblyEntity, SeqColEntity.NamingConvention convention) throws IOException {
+        SeqColExtendedDataEntity seqColNamesObject = new SeqColExtendedDataEntity().setAttributeType(
+                SeqColExtendedDataEntity.AttributeType.names);
+        JSONExtData seqColNamesArray = new JSONExtData();
+        List<String> namesList = new LinkedList<>();
+
+        for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
+            switch (convention) {
+                case ENA:
+                    namesList.add(chromosome.getEnaSequenceName());
+                    break;
+                case GENBANK:
+                    namesList.add(chromosome.getGenbankSequenceName());
+                    break;
+                case UCSC:
+                    namesList.add(chromosome.getUcscName());
+                    break;
+            }
+        }
+
+        seqColNamesArray.setObject(namesList);
+        seqColNamesObject.setObject(seqColNamesArray);
+        seqColNamesObject.setDigest(digestCalculator.generateDigest(seqColNamesArray.toString()));
+        return seqColNamesObject;
+    }
+
+    /**
+     * Return the seqCol lengths array object*/
+    public SeqColExtendedDataEntity constructSeqColLengthsObject(AssemblyEntity assemblyEntity) throws IOException {
+        SeqColExtendedDataEntity seqColLengthsObject = new SeqColExtendedDataEntity().setAttributeType(
+                SeqColExtendedDataEntity.AttributeType.lengths);
+        JSONExtData seqColLengthsArray = new JSONExtData();
+        List<String> lengthsList = new LinkedList<>();
+
+        for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
+            lengthsList.add(chromosome.getSeqLength().toString());
+        }
+        seqColLengthsArray.setObject(lengthsList);
+        seqColLengthsObject.setObject(seqColLengthsArray);
+        seqColLengthsObject.setDigest(digestCalculator.generateDigest(seqColLengthsArray.toString()));
+        return seqColLengthsObject;
+    }
+
+    /**
+     * Return the seqCol sequences array object*/
+    public SeqColExtendedDataEntity constructSeqColSequencesObject(AssemblySequenceEntity assemblySequenceEntity) throws IOException {
+        SeqColExtendedDataEntity seqColSequencesObject = new SeqColExtendedDataEntity().setAttributeType(
+                SeqColExtendedDataEntity.AttributeType.sequences);
+        JSONExtData seqColSequencesArray = new JSONExtData();
+        List<String> sequencesList = new LinkedList<>();
+
+        for (SeqColSequenceEntity sequence: assemblySequenceEntity.getSequences()) {
+            sequencesList.add(sequence.getSequenceMD5());
+        }
+        seqColSequencesArray.setObject(sequencesList);
+        seqColSequencesObject.setObject(seqColSequencesArray);
+        seqColSequencesObject.setDigest(digestCalculator.generateDigest(seqColSequencesArray.toString()));
+        return seqColSequencesObject;
+    }
+
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSource.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSource.java
@@ -12,7 +12,7 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.refget.DigestCalculator;
+import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
 
@@ -104,8 +104,8 @@ public class NCBISeqColDataSource implements SeqColDataSource{
                     break;
             }
         }
-        levelOneEntity.setObject(jsonLevelOne);
-        String digest0 = digestCalculator.generateDigest(levelOneEntity.toString());
+        levelOneEntity.setSeqColLevel1Object(jsonLevelOne);
+        String digest0 = digestCalculator.getSha512Digest(levelOneEntity.toString());
         levelOneEntity.setDigest(digest0);
         levelOneEntity.setNamingConvention(convention);
         return levelOneEntity;
@@ -146,8 +146,8 @@ public class NCBISeqColDataSource implements SeqColDataSource{
         }
 
         seqColNamesArray.setObject(namesList);
-        seqColNamesObject.setObject(seqColNamesArray);
-        seqColNamesObject.setDigest(digestCalculator.generateDigest(seqColNamesArray.toString()));
+        seqColNamesObject.setExtendedSeqColData(seqColNamesArray);
+        seqColNamesObject.setDigest(digestCalculator.getSha512Digest(seqColNamesArray.toString()));
         return seqColNamesObject;
     }
 
@@ -163,8 +163,8 @@ public class NCBISeqColDataSource implements SeqColDataSource{
             lengthsList.add(chromosome.getSeqLength().toString());
         }
         seqColLengthsArray.setObject(lengthsList);
-        seqColLengthsObject.setObject(seqColLengthsArray);
-        seqColLengthsObject.setDigest(digestCalculator.generateDigest(seqColLengthsArray.toString()));
+        seqColLengthsObject.setExtendedSeqColData(seqColLengthsArray);
+        seqColLengthsObject.setDigest(digestCalculator.getSha512Digest(seqColLengthsArray.toString()));
         return seqColLengthsObject;
     }
 
@@ -180,8 +180,8 @@ public class NCBISeqColDataSource implements SeqColDataSource{
             sequencesList.add(sequence.getSequenceMD5());
         }
         seqColSequencesArray.setObject(sequencesList);
-        seqColSequencesObject.setObject(seqColSequencesArray);
-        seqColSequencesObject.setDigest(digestCalculator.generateDigest(seqColSequencesArray.toString()));
+        seqColSequencesObject.setExtendedSeqColData(seqColSequencesArray);
+        seqColSequencesObject.setDigest(digestCalculator.getSha512Digest(seqColSequencesArray.toString()));
         return seqColSequencesObject;
     }
 

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSource.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSource.java
@@ -117,72 +117,10 @@ public class NCBISeqColDataSource implements SeqColDataSource{
                                                                    SeqColEntity.NamingConvention convention, String assemblyAccession) throws IOException {
         // Sorting the chromosomes' list (assemblyEntity) and the sequences' list (sequencesEntity) in the same order
         return Arrays.asList(
-                constructSeqColSequencesObject(assemblySequenceEntity),
-                constructSeqColNamesObject(assemblyEntity, convention),
-                constructSeqColLengthsObject(assemblyEntity)
+               SeqColExtendedDataEntity.constructSeqColSequencesObject(assemblySequenceEntity),
+               SeqColExtendedDataEntity.constructSeqColNamesObject(assemblyEntity, convention),
+               SeqColExtendedDataEntity.constructSeqColLengthsObject(assemblyEntity)
         );
-    }
-
-    /**
-     * Return the seqCol names array object*/
-    public SeqColExtendedDataEntity constructSeqColNamesObject(AssemblyEntity assemblyEntity, SeqColEntity.NamingConvention convention) throws IOException {
-        SeqColExtendedDataEntity seqColNamesObject = new SeqColExtendedDataEntity().setAttributeType(
-                SeqColExtendedDataEntity.AttributeType.names);
-        JSONExtData seqColNamesArray = new JSONExtData();
-        List<String> namesList = new LinkedList<>();
-
-        for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
-            switch (convention) {
-                case ENA:
-                    namesList.add(chromosome.getEnaSequenceName());
-                    break;
-                case GENBANK:
-                    namesList.add(chromosome.getGenbankSequenceName());
-                    break;
-                case UCSC:
-                    namesList.add(chromosome.getUcscName());
-                    break;
-            }
-        }
-
-        seqColNamesArray.setObject(namesList);
-        seqColNamesObject.setExtendedSeqColData(seqColNamesArray);
-        seqColNamesObject.setDigest(digestCalculator.getSha512Digest(seqColNamesArray.toString()));
-        return seqColNamesObject;
-    }
-
-    /**
-     * Return the seqCol lengths array object*/
-    public SeqColExtendedDataEntity constructSeqColLengthsObject(AssemblyEntity assemblyEntity) throws IOException {
-        SeqColExtendedDataEntity seqColLengthsObject = new SeqColExtendedDataEntity().setAttributeType(
-                SeqColExtendedDataEntity.AttributeType.lengths);
-        JSONExtData seqColLengthsArray = new JSONExtData();
-        List<String> lengthsList = new LinkedList<>();
-
-        for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
-            lengthsList.add(chromosome.getSeqLength().toString());
-        }
-        seqColLengthsArray.setObject(lengthsList);
-        seqColLengthsObject.setExtendedSeqColData(seqColLengthsArray);
-        seqColLengthsObject.setDigest(digestCalculator.getSha512Digest(seqColLengthsArray.toString()));
-        return seqColLengthsObject;
-    }
-
-    /**
-     * Return the seqCol sequences array object*/
-    public SeqColExtendedDataEntity constructSeqColSequencesObject(AssemblySequenceEntity assemblySequenceEntity) throws IOException {
-        SeqColExtendedDataEntity seqColSequencesObject = new SeqColExtendedDataEntity().setAttributeType(
-                SeqColExtendedDataEntity.AttributeType.sequences);
-        JSONExtData seqColSequencesArray = new JSONExtData();
-        List<String> sequencesList = new LinkedList<>();
-
-        for (SeqColSequenceEntity sequence: assemblySequenceEntity.getSequences()) {
-            sequencesList.add(sequence.getSequenceMD5());
-        }
-        seqColSequencesArray.setObject(sequencesList);
-        seqColSequencesObject.setExtendedSeqColData(seqColSequencesArray);
-        seqColSequencesObject.setDigest(digestCalculator.getSha512Digest(seqColSequencesArray.toString()));
-        return seqColSequencesObject;
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/SeqColDataSource.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/SeqColDataSource.java
@@ -1,0 +1,14 @@
+package uk.ac.ebi.eva.evaseqcol.datasource;
+
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
+
+import java.io.IOException;
+import java.util.Optional;
+
+
+public interface SeqColDataSource {
+    Optional<SeqColLevelOneEntity> getSeqColL1ByAssemblyAccession(
+            String accesison, SeqColEntity.NamingConvention namingConvention) throws IOException;
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/dus/AssemblySequenceReader.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/dus/AssemblySequenceReader.java
@@ -23,7 +23,7 @@ public abstract class AssemblySequenceReader {
         this.accession = accession;
     }
 
-    public AssemblySequenceEntity getAssemblySequencesEntity() throws IOException, NoSuchAlgorithmException {
+    public AssemblySequenceEntity getAssemblySequencesEntity() throws IOException {
         if(!fileParsed || assemblySequenceEntity == null){
             parseFile();
         }
@@ -33,7 +33,7 @@ public abstract class AssemblySequenceReader {
     // TODO: provide a method here that will call parseFile in the inheritees (a method prone to exceptions)
     //  and close the reader after parseFile exits.
 
-    protected abstract void parseFile() throws IOException, NullPointerException, NoSuchAlgorithmException;
+    protected abstract void parseFile() throws IOException, NullPointerException;
 
     public boolean ready() throws IOException {
         return reader.ready();

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/dus/NCBIAssemblySequenceReader.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/dus/NCBIAssemblySequenceReader.java
@@ -7,7 +7,6 @@ import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.security.NoSuchAlgorithmException;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -49,13 +48,6 @@ public class NCBIAssemblySequenceReader extends AssemblySequenceReader {
         assemblySequenceEntity.setSequences(sequences);
         fileParsed = true;
         reader.close();
-    }
-
-    /**
-     * Normalize the given sequence following the
-     * */
-    String calculateChecksum(String sequence) {
-        return "";
     }
 
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/dus/NCBIAssemblySequenceReader.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/dus/NCBIAssemblySequenceReader.java
@@ -17,7 +17,7 @@ public class NCBIAssemblySequenceReader extends AssemblySequenceReader {
     }
 
     @Override
-    protected void parseFile() throws IOException, NullPointerException, NoSuchAlgorithmException {
+    protected void parseFile() throws IOException, NullPointerException {
         if (reader == null){
             throw new NullPointerException("Cannot use AssemblySequenceReader without having a valid InputStreamReader.");
         }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColEntity.java
@@ -14,7 +14,6 @@ import org.hibernate.annotations.TypeDefs;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString
-@Data
 public abstract class SeqColEntity {
 
     protected String digest; // The level 0 digest

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColExtendedDataEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColExtendedDataEntity.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
+import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 
 import javax.persistence.Basic;
@@ -15,6 +16,9 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
 
 @Entity
 @TypeDefs({
@@ -50,4 +54,67 @@ public class SeqColExtendedDataEntity {
         return this;
     }
 
+    /**
+     * Return the seqCol names array object*/
+    public static SeqColExtendedDataEntity constructSeqColNamesObject(AssemblyEntity assemblyEntity, SeqColEntity.NamingConvention convention) throws IOException {
+        SeqColExtendedDataEntity seqColNamesObject = new SeqColExtendedDataEntity().setAttributeType(
+                SeqColExtendedDataEntity.AttributeType.names);
+        JSONExtData seqColNamesArray = new JSONExtData();
+        List<String> namesList = new LinkedList<>();
+
+        for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
+            switch (convention) {
+                case ENA:
+                    namesList.add(chromosome.getEnaSequenceName());
+                    break;
+                case GENBANK:
+                    namesList.add(chromosome.getGenbankSequenceName());
+                    break;
+                case UCSC:
+                    namesList.add(chromosome.getUcscName());
+                    break;
+            }
+        }
+        SHA512Calculator sha512Calculator = new SHA512Calculator();
+        seqColNamesArray.setObject(namesList);
+        seqColNamesObject.setExtendedSeqColData(seqColNamesArray);
+        seqColNamesObject.setDigest(sha512Calculator.calculateChecksum(seqColNamesArray.toString()));
+        return seqColNamesObject;
+    }
+
+    /**
+     * Return the seqCol lengths array object*/
+    public static SeqColExtendedDataEntity constructSeqColLengthsObject(AssemblyEntity assemblyEntity) throws IOException {
+        SeqColExtendedDataEntity seqColLengthsObject = new SeqColExtendedDataEntity().setAttributeType(
+                SeqColExtendedDataEntity.AttributeType.lengths);
+        JSONExtData seqColLengthsArray = new JSONExtData();
+        List<String> lengthsList = new LinkedList<>();
+
+        for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
+            lengthsList.add(chromosome.getSeqLength().toString());
+        }
+        SHA512Calculator sha512Calculator = new SHA512Calculator();
+        seqColLengthsArray.setObject(lengthsList);
+        seqColLengthsObject.setExtendedSeqColData(seqColLengthsArray);
+        seqColLengthsObject.setDigest(sha512Calculator.calculateChecksum(seqColLengthsArray.toString()));
+        return seqColLengthsObject;
+    }
+
+    /**
+     * Return the seqCol sequences array object*/
+    public static SeqColExtendedDataEntity constructSeqColSequencesObject(AssemblySequenceEntity assemblySequenceEntity) throws IOException {
+        SeqColExtendedDataEntity seqColSequencesObject = new SeqColExtendedDataEntity().setAttributeType(
+                SeqColExtendedDataEntity.AttributeType.sequences);
+        JSONExtData seqColSequencesArray = new JSONExtData();
+        List<String> sequencesList = new LinkedList<>();
+
+        for (SeqColSequenceEntity sequence: assemblySequenceEntity.getSequences()) {
+            sequencesList.add(sequence.getSequenceMD5());
+        }
+        SHA512Calculator sha512Calculator = new SHA512Calculator();
+        seqColSequencesArray.setObject(sequencesList);
+        seqColSequencesObject.setExtendedSeqColData(seqColSequencesArray);
+        seqColSequencesObject.setDigest(sha512Calculator.calculateChecksum(seqColSequencesArray.toString()));
+        return seqColSequencesObject;
+    }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
@@ -29,7 +29,7 @@ public class SeqColLevelOneEntity extends SeqColEntity{
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
-    @Basic(fetch = FetchType.EAGER)
+    @Basic(fetch = FetchType.LAZY)
     private JSONLevelOne seqColLevel1Object;
 
     @Id

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
@@ -29,7 +29,6 @@ public class SeqColLevelOneEntity extends SeqColEntity{
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
-    @Basic(fetch = FetchType.LAZY)
     private JSONLevelOne seqColLevel1Object;
 
     @Id

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
@@ -29,6 +29,7 @@ public class SeqColLevelOneEntity extends SeqColEntity{
 
     @Type(type = "jsonb")
     @Column(columnDefinition = "jsonb")
+    @Basic(fetch = FetchType.EAGER)
     private JSONLevelOne seqColLevel1Object;
 
     @Id

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelTwoEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelTwoEntity.java
@@ -1,14 +1,22 @@
 package uk.ac.ebi.eva.evaseqcol.entities;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class SeqColLevelTwoEntity extends SeqColEntity{
 
     private List<String> sequences;
     private List<String> names;
     private List<String> lengths;
 
+    public SeqColLevelTwoEntity setDigest(String digest) {
+        this.digest = digest;
+        return this;
+    }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/AssemblySequenceNotFoundException.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/AssemblySequenceNotFoundException.java
@@ -1,0 +1,8 @@
+package uk.ac.ebi.eva.evaseqcol.exception;
+
+public class AssemblySequenceNotFoundException extends RuntimeException{
+
+    public AssemblySequenceNotFoundException(String accession) {
+        super("No assembly corresponding to accession " + accession + " could be found");
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/DuplicateSeqColException.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/DuplicateSeqColException.java
@@ -1,8 +1,8 @@
 package uk.ac.ebi.eva.evaseqcol.exception;
 
-public class duplicateSeqColException extends RuntimeException {
+public class DuplicateSeqColException extends RuntimeException {
 
-    public duplicateSeqColException(String digest) {
+    public DuplicateSeqColException(String digest) {
         super("A similar seqCol already exists with digest " + digest);
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/ExtendedDataNotFoundException.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/ExtendedDataNotFoundException.java
@@ -1,0 +1,8 @@
+package uk.ac.ebi.eva.evaseqcol.exception;
+
+public class ExtendedDataNotFoundException extends RuntimeException{
+    
+    public ExtendedDataNotFoundException(String digest) {
+        super("No seqcol extended data with digest " + digest + " could be found in the db");
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/SeqColNotFoundException.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/SeqColNotFoundException.java
@@ -2,7 +2,7 @@ package uk.ac.ebi.eva.evaseqcol.exception;
 
 public class SeqColNotFoundException extends RuntimeException {
 
-    public SeqColNotFoundException(String accession) {
-        super("No seqCol data corresponding to accession " + accession + " could be found");
+    public SeqColNotFoundException(String digest) {
+        super("No seqCol corresponding to digest " + digest + " could be found in DB");
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/SeqColNotFoundException.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/SeqColNotFoundException.java
@@ -1,0 +1,8 @@
+package uk.ac.ebi.eva.evaseqcol.exception;
+
+public class SeqColNotFoundException extends RuntimeException {
+
+    public SeqColNotFoundException(String accession) {
+        super("No seqCol data corresponding to accession " + accession + " could be found");
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/duplicateSeqColException.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/duplicateSeqColException.java
@@ -1,0 +1,8 @@
+package uk.ac.ebi.eva.evaseqcol.exception;
+
+public class duplicateSeqColException extends RuntimeException {
+
+    public duplicateSeqColException(String digest) {
+        super("A similar seqCol already exists with digest " + digest);
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/refget/SHA512Calculator.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/refget/SHA512Calculator.java
@@ -31,4 +31,16 @@ public class SHA512Calculator extends ChecksumCalculator{
         md.update(text.getBytes());
         return md.digest();
     }
+
+
+    public byte[] SHA512HashBytes(byte[] bytes) {
+        MessageDigest md;
+        try {
+            md = MessageDigest.getInstance("SHA-512");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        md.update(bytes);
+        return md.digest();
+    }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColExtendedDataRepository.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColExtendedDataRepository.java
@@ -1,12 +1,28 @@
 package uk.ac.ebi.eva.evaseqcol.repo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
+import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SeqColExtendedDataRepository extends JpaRepository<SeqColExtendedDataEntity, String> {
     public SeqColExtendedDataEntity findSeqColExtendedDataEntityByDigest(String digest);
 
+    @Query(value = "SELECT c.object->>'object' as object from sequence_collections_l1 p " +
+            "right join seqcol_extended_data c ON p.object->>'names' = c.digest" +
+            " or p.object->>'sequences' = c.digest" +
+            " or p.object->>'lengths' = c.digest" +
+            " WHERE p.digest= :level0Digest", nativeQuery = true)
+    // To be reviewed. PB: We should identify each object of the list (lengths, sequences or names)
+    public Optional<List<String>> getSeqColExtendedDataByLevel0Digest(@Param("level0Digest") String seqColDigest);
+
+    public Optional<SeqColExtendedDataEntity> getSeqColExtendedDataEntityByDigest(String digest);
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColExtendedDataRepository.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColExtendedDataRepository.java
@@ -7,5 +7,6 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 
 @Repository
 public interface SeqColExtendedDataRepository extends JpaRepository<SeqColExtendedDataEntity, String> {
+    public SeqColExtendedDataEntity findSeqColExtendedDataEntityByDigest(String digest);
 
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColLevelOneRepository.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColLevelOneRepository.java
@@ -7,5 +7,6 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 
 @Repository
 public interface SeqColLevelOneRepository extends JpaRepository<SeqColLevelOneEntity, String> {
+    public SeqColLevelOneEntity findSeqColLevelOneEntityByDigest(String digest);
 
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColLevelOneRepository.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColLevelOneRepository.java
@@ -9,4 +9,5 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 public interface SeqColLevelOneRepository extends JpaRepository<SeqColLevelOneEntity, String> {
     public SeqColLevelOneEntity findSeqColLevelOneEntityByDigest(String digest);
 
+    long countSeqColLevelOneEntitiesByDigest(String digest);
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataService.java
@@ -9,19 +9,20 @@ import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.ChromosomeEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
+import uk.ac.ebi.eva.evaseqcol.refget.DigestCalculator;
 import uk.ac.ebi.eva.evaseqcol.repo.SeqColExtendedDataRepository;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 
-import java.util.ArrayList;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 public class SeqColExtendedDataService {
@@ -29,6 +30,10 @@ public class SeqColExtendedDataService {
     @Autowired
     private SeqColExtendedDataRepository repository;
 
+    private DigestCalculator digestCalculator = new DigestCalculator();
+
+    /**
+     * Add a seqCol's attribute; names, lengths or sequences, to the database*/
     public Optional<SeqColExtendedDataEntity> addSeqColExtendedData(SeqColExtendedDataEntity seqColExtendedData){
         try {
             SeqColExtendedDataEntity seqCol = repository.save(seqColExtendedData);
@@ -36,8 +41,6 @@ public class SeqColExtendedDataService {
         } catch (Exception e){
             // TODO : THROW A SELF MADE EXCEPTION
             e.printStackTrace();
-            //System.out.println("SeqcolL2 with digest " + seqColExtendedData.getDigest() + " already exists in the db !!");
-
         }
         return Optional.empty();
     }
@@ -47,66 +50,144 @@ public class SeqColExtendedDataService {
         return repository.saveAll(seqColExtendedDataList);
     }
 
-    public List<SeqColExtendedDataEntity> getAll() {
-        return repository.findAll();
+    /**
+     * Return the extendedData object for the given digest*/
+    Optional<SeqColExtendedDataEntity> getExtendedAttributeByDigest(String digest) {
+        SeqColExtendedDataEntity dataEntity = repository.findSeqColExtendedDataEntityByDigest(digest);
+        return Optional.of(dataEntity);
     }
 
+
     /**
-     * Return the 3 extracted seqcol objects (names, lengths and sequences) of the given naming convention*/
-     public List<SeqColExtendedDataEntity> constructLevelTwoSeqCols(AssemblyEntity assemblyEntity, AssemblySequenceEntity sequenceEntity,
-                                                                    SeqColEntity.NamingConvention convention, String accession){
-        SeqColExtendedDataEntity namesEntity;
-        SeqColExtendedDataEntity lengthsEntity;
-        SeqColExtendedDataEntity sequencesEntity;
-        JSONExtData jsonNamesObject = new JSONExtData();
-        JSONExtData jsonLengthsObject = new JSONExtData();
-        JSONExtData jsonSequencesObject = new JSONExtData();
-        List<String> sequencesNamesObject = new LinkedList<>(); // Array of sequences' names
-        List<String> sequencesLengthsObject = new LinkedList<>(); // Array of sequences' lengths
-        List<String> sequencesObject = new LinkedList<>(); // // Array of actual sequences
+     * Return the seqCol names array object*/
+    SeqColExtendedDataEntity constructSeqColNamesObject(AssemblyEntity assemblyEntity, SeqColEntity.NamingConvention convention) throws IOException {
+        SeqColExtendedDataEntity seqColNamesObject = new SeqColExtendedDataEntity().setAttributeType(
+                SeqColExtendedDataEntity.AttributeType.names);
+        JSONExtData seqColNamesArray = new JSONExtData();
+        List<String> namesList = new LinkedList<>();
 
-
-
-        // Setting the sequences' names
         for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
             switch (convention) {
                 case ENA:
-                    sequencesNamesObject.add(chromosome.getEnaSequenceName());
+                    namesList.add(chromosome.getEnaSequenceName());
                     break;
                 case GENBANK:
-                    sequencesNamesObject.add(chromosome.getGenbankSequenceName());
+                    namesList.add(chromosome.getGenbankSequenceName());
                     break;
                 case UCSC:
-                    sequencesNamesObject.add(chromosome.getUcscName());
+                    namesList.add(chromosome.getUcscName());
                     break;
             }
-            sequencesLengthsObject.add(chromosome.getSeqLength().toString());
         }
 
-        // Setting actual sequences
-        for (SeqColSequenceEntity sequence: sequenceEntity.getSequences()) {
-            sequencesObject.add(sequence.getSequenceMD5());
+        seqColNamesArray.setObject(namesList);
+        seqColNamesObject.setObject(seqColNamesArray);
+        seqColNamesObject.setDigest(digestCalculator.generateDigest(seqColNamesArray.toString()));
+        return seqColNamesObject;
+    }
+
+    /**
+     * Return the seqCol lengths array object*/
+    public SeqColExtendedDataEntity constructSeqColLengthsObject(AssemblyEntity assemblyEntity) throws IOException {
+        SeqColExtendedDataEntity seqColLengthsObject = new SeqColExtendedDataEntity().setAttributeType(
+                SeqColExtendedDataEntity.AttributeType.lengths);
+        JSONExtData seqColLengthsArray = new JSONExtData();
+        List<String> lengthsList = new LinkedList<>();
+
+        for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
+            lengthsList.add(chromosome.getSeqLength().toString());
         }
+        seqColLengthsArray.setObject(lengthsList);
+        seqColLengthsObject.setObject(seqColLengthsArray);
+        seqColLengthsObject.setDigest(digestCalculator.generateDigest(seqColLengthsArray.toString()));
+        return seqColLengthsObject;
+    }
 
-        jsonNamesObject.setObject(sequencesNamesObject);
-        String namesDigest = UUID.randomUUID().toString(); // TODO: CALCULATE THE DIGEST OF THE sequencesNamesObject AND PUT IT HERE
-        namesEntity = new SeqColExtendedDataEntity().setExtendedSeqColData(jsonNamesObject);
-        namesEntity.setDigest(namesDigest);
+    /**
+     * Return the seqCol sequences array object*/
+    public SeqColExtendedDataEntity constructSeqColSequencesObject(AssemblySequenceEntity assemblySequenceEntity) throws IOException {
+        SeqColExtendedDataEntity seqColSequencesObject = new SeqColExtendedDataEntity().setAttributeType(
+                SeqColExtendedDataEntity.AttributeType.sequences);
+        JSONExtData seqColSequencesArray = new JSONExtData();
+        List<String> sequencesList = new LinkedList<>();
 
-        jsonLengthsObject.setObject(sequencesLengthsObject);
-        String lengthsDigest = UUID.randomUUID().toString(); // TODO: CALCULATE THE DIGEST OF THE sequencesLengthsObject AND PUT IT HERE
-        lengthsEntity = new SeqColExtendedDataEntity().setExtendedSeqColData(jsonLengthsObject);
-        lengthsEntity.setDigest(lengthsDigest);
+        for (SeqColSequenceEntity sequence: assemblySequenceEntity.getSequences()) {
+            sequencesList.add(sequence.getSequenceMD5());
+        }
+        seqColSequencesArray.setObject(sequencesList);
+        seqColSequencesObject.setObject(seqColSequencesArray);
+        seqColSequencesObject.setDigest(digestCalculator.generateDigest(seqColSequencesArray.toString()));
+        return seqColSequencesObject;
+    }
 
-        jsonSequencesObject.setObject(sequencesObject);
-        String sequencesDigest = UUID.randomUUID().toString(); // TODO: CALCULATE THE DIGEST OF THE sequencesObject AND PUT IT HERE
-        sequencesEntity = new SeqColExtendedDataEntity().setExtendedSeqColData(jsonSequencesObject);
-        sequencesEntity.setDigest(sequencesDigest);
-
-        List<SeqColExtendedDataEntity> entities = new ArrayList<>(
-                Arrays.asList(namesEntity, lengthsEntity, sequencesEntity)
+    /**
+     * Return the 3 extended data objects (names, lengths and sequences) of the given naming convention*/
+    List<SeqColExtendedDataEntity> constructExtendedSeqColDataList(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
+                                                            SeqColEntity.NamingConvention convention, String assemblyAccession) throws IOException {
+        // Sorting the chromosomes' list (assemblyEntity) and the sequences' list (sequencesEntity) in the same order
+        sortReportAndSequencesBySequenceIdentifier(assemblyEntity, assemblySequenceEntity, assemblyAccession);
+        return Arrays.asList(
+                constructSeqColSequencesObject(assemblySequenceEntity),
+                constructSeqColNamesObject(assemblyEntity, convention),
+                constructSeqColLengthsObject(assemblyEntity)
         );
-        return entities;
+    }
+
+    /**
+     * Construct and return a Level Two (with exploded data) SeqCol entity out of the given assemblyEntity and the
+     * assemblySequencesEntity*/
+    SeqColLevelTwoEntity constructSeqColLevelTwo(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
+                                                 SeqColEntity.NamingConvention convention, String accession) throws IOException {
+        SeqColLevelTwoEntity seqColLevelTwo = new SeqColLevelTwoEntity();
+        sortReportAndSequencesBySequenceIdentifier(assemblyEntity, assemblySequenceEntity, accession);
+        SeqColExtendedDataEntity extendedNamesData = constructSeqColNamesObject(assemblyEntity, convention);
+        SeqColExtendedDataEntity extendedLengthsData = constructSeqColLengthsObject(assemblyEntity);
+        SeqColExtendedDataEntity extendedSequencesData = constructSeqColSequencesObject(assemblySequenceEntity);
+        seqColLevelTwo.setNames(extendedNamesData.getObject().getObject());
+        seqColLevelTwo.setLengths(extendedLengthsData.getObject().getObject());
+        seqColLevelTwo.setSequences(extendedSequencesData.getObject().getObject());
+        return seqColLevelTwo;
+    }
+
+    /**
+     * Sort the chromosome list of the assemblyEntity and the sequences list of the assemblySequenceEntity
+     * by the sequence identifier */
+    void sortReportAndSequencesBySequenceIdentifier(AssemblyEntity assemblyEntity, AssemblySequenceEntity sequenceEntity,
+                                                    String accession) {
+        String accessionType = getAccessionType(accession);
+
+        Comparator<ChromosomeEntity> chromosomeComparator = (o1, o2) -> {
+            String identifier1 = new String();
+            String identifier2 = new String();
+            switch (accessionType) {
+                case "GCF":
+                    identifier1 = o1.getRefseq();
+                    identifier2 = o2.getRefseq();
+                    break;
+                case "GCA":
+                    identifier1 = o1.getInsdcAccession();
+                    identifier2 = o2.getInsdcAccession();
+                    break;
+            }
+
+            String substring1 = identifier1.substring(identifier1.indexOf(".") + 1, identifier1.length());
+            String substring2 = identifier2.substring(identifier2.indexOf(".") + 1, identifier2.length());
+            if (!substring1.equals(substring2))
+                return substring1.compareTo(substring2);
+            return identifier1.substring(0,identifier1.indexOf(".")).compareTo(identifier2.substring(0,identifier2.indexOf(".")));
+        };
+        Collections.sort(assemblyEntity.getChromosomes(), chromosomeComparator);
+        Comparator<SeqColSequenceEntity> sequenceComparator = (o1, o2) -> {
+            String identifier = o1.getRefseq();
+            String identifier1 = o2.getRefseq();
+            String substring1 = identifier.substring(identifier.indexOf(".") + 1, identifier.length());
+            String substring2 = identifier1.substring(identifier1.indexOf(".") + 1, identifier1.length());
+            if (!substring1.equals(substring2))
+                return substring1.compareTo(substring2);
+            return identifier.substring(0,identifier.indexOf(".")).compareTo(identifier1.substring(0,identifier1.indexOf(".")));
+        };
+        Collections.sort(sequenceEntity.getSequences(), sequenceComparator);
+
     }
 
     /**
@@ -117,5 +198,4 @@ public class SeqColExtendedDataService {
         else
             return "GCF"; // Refseq accession
     }
-
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataService.java
@@ -9,18 +9,14 @@ import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
-import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.exception.ExtendedDataNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
 import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
 import uk.ac.ebi.eva.evaseqcol.repo.SeqColExtendedDataRepository;
-import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -79,77 +75,14 @@ public class SeqColExtendedDataService {
         return Optional.of(dataEntity);
     }
 
-
-    /**
-     * Return the seqCol names array object*/
-    SeqColExtendedDataEntity constructSeqColNamesObject(AssemblyEntity assemblyEntity, SeqColEntity.NamingConvention convention) throws IOException {
-        SeqColExtendedDataEntity seqColNamesObject = new SeqColExtendedDataEntity().setAttributeType(
-                SeqColExtendedDataEntity.AttributeType.names);
-        JSONExtData seqColNamesArray = new JSONExtData();
-        List<String> namesList = new LinkedList<>();
-
-        for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
-            switch (convention) {
-                case ENA:
-                    namesList.add(chromosome.getEnaSequenceName());
-                    break;
-                case GENBANK:
-                    namesList.add(chromosome.getGenbankSequenceName());
-                    break;
-                case UCSC:
-                    namesList.add(chromosome.getUcscName());
-                    break;
-            }
-        }
-
-        seqColNamesArray.setObject(namesList);
-        seqColNamesObject.setExtendedSeqColData(seqColNamesArray);
-        seqColNamesObject.setDigest(sha512Calculator.calculateChecksum(seqColNamesArray.toString()));
-        return seqColNamesObject;
-    }
-
-    /**
-     * Return the seqCol lengths array object*/
-    public SeqColExtendedDataEntity constructSeqColLengthsObject(AssemblyEntity assemblyEntity) throws IOException {
-        SeqColExtendedDataEntity seqColLengthsObject = new SeqColExtendedDataEntity().setAttributeType(
-                SeqColExtendedDataEntity.AttributeType.lengths);
-        JSONExtData seqColLengthsArray = new JSONExtData();
-        List<String> lengthsList = new LinkedList<>();
-
-        for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
-            lengthsList.add(chromosome.getSeqLength().toString());
-        }
-        seqColLengthsArray.setObject(lengthsList);
-        seqColLengthsObject.setExtendedSeqColData(seqColLengthsArray);
-        seqColLengthsObject.setDigest(sha512Calculator.calculateChecksum(seqColLengthsArray.toString()));
-        return seqColLengthsObject;
-    }
-
-    /**
-     * Return the seqCol sequences array object*/
-    public SeqColExtendedDataEntity constructSeqColSequencesObject(AssemblySequenceEntity assemblySequenceEntity) throws IOException {
-        SeqColExtendedDataEntity seqColSequencesObject = new SeqColExtendedDataEntity().setAttributeType(
-                SeqColExtendedDataEntity.AttributeType.sequences);
-        JSONExtData seqColSequencesArray = new JSONExtData();
-        List<String> sequencesList = new LinkedList<>();
-
-        for (SeqColSequenceEntity sequence: assemblySequenceEntity.getSequences()) {
-            sequencesList.add(sequence.getSequenceMD5());
-        }
-        seqColSequencesArray.setObject(sequencesList);
-        seqColSequencesObject.setExtendedSeqColData(seqColSequencesArray);
-        seqColSequencesObject.setDigest(sha512Calculator.calculateChecksum(seqColSequencesArray.toString()));
-        return seqColSequencesObject;
-    }
-
     /**
      * Return the 3 extended data objects (names, lengths and sequences) of the given naming convention*/
     public List<SeqColExtendedDataEntity> constructExtendedSeqColDataList(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
-                                                            SeqColEntity.NamingConvention convention, String assemblyAccession) throws IOException {
+                                                            SeqColEntity.NamingConvention convention) throws IOException {
         return Arrays.asList(
-                constructSeqColSequencesObject(assemblySequenceEntity),
-                constructSeqColNamesObject(assemblyEntity, convention),
-                constructSeqColLengthsObject(assemblyEntity)
+                SeqColExtendedDataEntity.constructSeqColSequencesObject(assemblySequenceEntity),
+                SeqColExtendedDataEntity.constructSeqColNamesObject(assemblyEntity, convention),
+                SeqColExtendedDataEntity.constructSeqColLengthsObject(assemblyEntity)
         );
     }
 
@@ -157,11 +90,11 @@ public class SeqColExtendedDataService {
      * Construct and return a Level Two (with exploded data) SeqCol entity out of the given assemblyEntity and the
      * assemblySequencesEntity*/
     public SeqColLevelTwoEntity constructSeqColLevelTwo(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
-                                                 SeqColEntity.NamingConvention convention, String accession) throws IOException {
+                                                 SeqColEntity.NamingConvention convention) throws IOException {
         SeqColLevelTwoEntity seqColLevelTwo = new SeqColLevelTwoEntity();
-        SeqColExtendedDataEntity extendedNamesData = constructSeqColNamesObject(assemblyEntity, convention);
-        SeqColExtendedDataEntity extendedLengthsData = constructSeqColLengthsObject(assemblyEntity);
-        SeqColExtendedDataEntity extendedSequencesData = constructSeqColSequencesObject(assemblySequenceEntity);
+        SeqColExtendedDataEntity extendedNamesData = SeqColExtendedDataEntity.constructSeqColNamesObject(assemblyEntity, convention);
+        SeqColExtendedDataEntity extendedLengthsData = SeqColExtendedDataEntity.constructSeqColLengthsObject(assemblyEntity);
+        SeqColExtendedDataEntity extendedSequencesData = SeqColExtendedDataEntity.constructSeqColSequencesObject(assemblySequenceEntity);
         seqColLevelTwo.setNames(extendedNamesData.getExtendedSeqColData().getObject());
         seqColLevelTwo.setLengths(extendedLengthsData.getExtendedSeqColData().getObject());
         seqColLevelTwo.setSequences(extendedSequencesData.getExtendedSeqColData().getObject());

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataService.java
@@ -20,8 +20,6 @@ import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -146,7 +144,7 @@ public class SeqColExtendedDataService {
 
     /**
      * Return the 3 extended data objects (names, lengths and sequences) of the given naming convention*/
-    List<SeqColExtendedDataEntity> constructExtendedSeqColDataList(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
+    public List<SeqColExtendedDataEntity> constructExtendedSeqColDataList(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
                                                             SeqColEntity.NamingConvention convention, String assemblyAccession) throws IOException {
         return Arrays.asList(
                 constructSeqColSequencesObject(assemblySequenceEntity),
@@ -158,7 +156,7 @@ public class SeqColExtendedDataService {
     /**
      * Construct and return a Level Two (with exploded data) SeqCol entity out of the given assemblyEntity and the
      * assemblySequencesEntity*/
-    SeqColLevelTwoEntity constructSeqColLevelTwo(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
+    public SeqColLevelTwoEntity constructSeqColLevelTwo(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
                                                  SeqColEntity.NamingConvention convention, String accession) throws IOException {
         SeqColLevelTwoEntity seqColLevelTwo = new SeqColLevelTwoEntity();
         SeqColExtendedDataEntity extendedNamesData = constructSeqColNamesObject(assemblyEntity, convention);

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -37,7 +37,7 @@ public class SeqColLevelOneService {
         if (seqColL11 != null) {
             return Optional.of(seqColL11);
         } else {
-            throw new SeqColNotFoundException(digest);
+            return Optional.empty();
         }
     }
 

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -7,6 +7,7 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
+import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.repo.SeqColLevelOneRepository;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
 
@@ -35,8 +36,9 @@ public class SeqColLevelOneService {
         SeqColLevelOneEntity seqColL11 = repository.findSeqColLevelOneEntityByDigest(digest);
         if (seqColL11 != null) {
             return Optional.of(seqColL11);
+        } else {
+            throw new SeqColNotFoundException(digest);
         }
-        return Optional.empty();
     }
 
     public long countSeqColLevelOneEntitiesByDigest(String digest) {

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -49,7 +49,7 @@ public class SeqColLevelOneService {
     /**
      * Construct a seqCol level 1 entity out of three seqCol level 2 entities that
      * hold names, lengths and sequences objects*/
-    SeqColLevelOneEntity constructSeqColLevelOne(List<SeqColExtendedDataEntity> extendedDataEntities,
+    public SeqColLevelOneEntity constructSeqColLevelOne(List<SeqColExtendedDataEntity> extendedDataEntities,
                                                  SeqColEntity.NamingConvention convention) throws IOException {
         SeqColLevelOneEntity levelOneEntity = new SeqColLevelOneEntity();
         JSONLevelOne jsonLevelOne = new JSONLevelOne();

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -34,7 +34,10 @@ public class SeqColLevelOneService {
 
     public Optional<SeqColLevelOneEntity> getSeqColLevelOneByDigest(String digest){
         SeqColLevelOneEntity seqColL11 = repository.findSeqColLevelOneEntityByDigest(digest);
-        return Optional.of(seqColL11);
+        if (seqColL11 != null) {
+            return Optional.of(seqColL11);
+        }
+        return Optional.empty();
     }
 
     public List<SeqColLevelOneEntity> getAllSeqColLevelOneObjects(){

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
-import uk.ac.ebi.eva.evaseqcol.refget.DigestCalculator;
+import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
 import uk.ac.ebi.eva.evaseqcol.repo.SeqColLevelOneRepository;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
 
@@ -28,7 +28,6 @@ public class SeqColLevelOneService {
     public Optional<SeqColLevelOneEntity> addSequenceCollectionL1(SeqColLevelOneEntity seqColLevelOne){
         SeqColLevelOneEntity seqCol = repository.save(seqColLevelOne);
         return Optional.of(seqCol);
-        // TODO: Handle exceptions
     }
 
 
@@ -40,6 +39,9 @@ public class SeqColLevelOneService {
         return Optional.empty();
     }
 
+    public long countSeqColLevelOneEntitiesByDigest(String digest) {
+        return repository.countSeqColLevelOneEntitiesByDigest(digest);
+    }
     public List<SeqColLevelOneEntity> getAllSeqColLevelOneObjects(){
         return repository.findAll();
     }
@@ -64,8 +66,8 @@ public class SeqColLevelOneService {
                     break;
             }
         }
-        levelOneEntity.setObject(jsonLevelOne);
-        String digest0 = digestCalculator.generateDigest(levelOneEntity.toString());
+        levelOneEntity.setSeqColLevel1Object(jsonLevelOne);
+        String digest0 = digestCalculator.getSha512Digest(levelOneEntity.toString());
         levelOneEntity.setDigest(digest0);
         levelOneEntity.setNamingConvention(convention);
         return levelOneEntity;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
@@ -37,13 +37,13 @@ public class SeqColLevelTwoService {
         for (SeqColExtendedDataEntity extendedData: extendedAttributes) {
             switch (extendedData.getAttributeType()) {
                 case lengths:
-                    levelTwoEntity.setLengths(extendedData.getObject().getObject());
+                    levelTwoEntity.setLengths(extendedData.getExtendedSeqColData().getObject());
                     break;
                 case names:
-                    levelTwoEntity.setNames(extendedData.getObject().getObject());
+                    levelTwoEntity.setNames(extendedData.getExtendedSeqColData().getObject());
                     break;
                 case sequences:
-                    levelTwoEntity.setSequences(extendedData.getObject().getObject());
+                    levelTwoEntity.setSequences(extendedData.getExtendedSeqColData().getObject());
                     break;
             }
         }
@@ -54,21 +54,21 @@ public class SeqColLevelTwoService {
      * Return the list of the extended (exploded) seqCol attributes; names, lengths and sequences
      * Given the corresponding seqCol level 1 object*/
     private List<SeqColExtendedDataEntity> getExtendedAttributes(SeqColLevelOneEntity levelOneEntity) {
-        Optional<SeqColExtendedDataEntity> extendedSequences = extendedDataService.getExtendedAttributeByDigest(levelOneEntity.getObject().getSequences());
+        Optional<SeqColExtendedDataEntity> extendedSequences = extendedDataService.getExtendedAttributeByDigest(levelOneEntity.getSeqColLevel1Object().getSequences());
         if (!extendedSequences.isPresent()) {
-            throw new RuntimeException("Extended sequences data with digest: " + levelOneEntity.getObject().getSequences() + " not found");
+            throw new RuntimeException("Extended sequences data with digest: " + levelOneEntity.getSeqColLevel1Object().getSequences() + " not found");
         }
         extendedSequences.get().setAttributeType(SeqColExtendedDataEntity.AttributeType.sequences);
 
-        Optional<SeqColExtendedDataEntity> extendedLengths = extendedDataService.getExtendedAttributeByDigest(levelOneEntity.getObject().getLengths());
+        Optional<SeqColExtendedDataEntity> extendedLengths = extendedDataService.getExtendedAttributeByDigest(levelOneEntity.getSeqColLevel1Object().getLengths());
         if (!extendedLengths.isPresent()) {
-            throw new RuntimeException("Extended lengths data with digest: " + levelOneEntity.getObject().getLengths() + " not found");
+            throw new RuntimeException("Extended lengths data with digest: " + levelOneEntity.getSeqColLevel1Object().getLengths() + " not found");
         }
         extendedLengths.get().setAttributeType(SeqColExtendedDataEntity.AttributeType.lengths);
 
-        Optional<SeqColExtendedDataEntity> extendedNames = extendedDataService.getExtendedAttributeByDigest(levelOneEntity.getObject().getNames());
+        Optional<SeqColExtendedDataEntity> extendedNames = extendedDataService.getExtendedAttributeByDigest(levelOneEntity.getSeqColLevel1Object().getNames());
         if (!extendedNames.isPresent()) {
-            throw new RuntimeException("Extended names data with digest: " + levelOneEntity.getObject().getNames() + " not found");
+            throw new RuntimeException("Extended names data with digest: " + levelOneEntity.getSeqColLevel1Object().getNames() + " not found");
         }
         extendedNames.get().setAttributeType(SeqColExtendedDataEntity.AttributeType.names);
 

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
@@ -1,0 +1,82 @@
+package uk.ac.ebi.eva.evaseqcol.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class SeqColLevelTwoService {
+
+    @Autowired
+    private SeqColExtendedDataService extendedDataService;
+
+    @Autowired
+    private SeqColLevelOneService levelOneService;
+
+    /**
+     * Make 2 recursive lookups to retrieve and construct the seqCol level 2 object
+     * @param digest: level 0 seqCol digest*/
+    public Optional<SeqColLevelTwoEntity> getSeqColLevelTwoByDigest(String digest) {
+        // 1 DATABASE LOOKUP
+        Optional<SeqColLevelOneEntity> levelOneEntity = levelOneService.getSeqColLevelOneByDigest(digest);
+        if (!levelOneEntity.isPresent()) {
+            //TODO THROW EXCEPTION
+            System.out.println("EXCPETION: seqCol with digest: " + digest + "doesn't exists !");
+            return Optional.empty();
+        }
+        // 2 DATABASE LOOKUPS (1 RECURSIVE CALL)
+        List<SeqColExtendedDataEntity> extendedAttributes = getExtendedAttributes(levelOneEntity.get());
+        SeqColLevelTwoEntity levelTwoEntity = new SeqColLevelTwoEntity();
+        for (SeqColExtendedDataEntity extendedData: extendedAttributes) {
+            switch (extendedData.getAttributeType()) {
+                case lengths:
+                    levelTwoEntity.setLengths(extendedData.getObject().getObject());
+                    break;
+                case names:
+                    levelTwoEntity.setNames(extendedData.getObject().getObject());
+                    break;
+                case sequences:
+                    levelTwoEntity.setSequences(extendedData.getObject().getObject());
+                    break;
+            }
+        }
+        return Optional.of(levelTwoEntity);
+    }
+
+    /**
+     * Return the list of the extended (exploded) seqCol attributes; names, lengths and sequences
+     * Given the corresponding seqCol level 1 object*/
+    private List<SeqColExtendedDataEntity> getExtendedAttributes(SeqColLevelOneEntity levelOneEntity) {
+        Optional<SeqColExtendedDataEntity> extendedSequences = extendedDataService.getExtendedAttributeByDigest(levelOneEntity.getObject().getSequences());
+        if (!extendedSequences.isPresent()) {
+            throw new RuntimeException("Extended sequences data with digest: " + levelOneEntity.getObject().getSequences() + " not found");
+        }
+        extendedSequences.get().setAttributeType(SeqColExtendedDataEntity.AttributeType.sequences);
+
+        Optional<SeqColExtendedDataEntity> extendedLengths = extendedDataService.getExtendedAttributeByDigest(levelOneEntity.getObject().getLengths());
+        if (!extendedLengths.isPresent()) {
+            throw new RuntimeException("Extended lengths data with digest: " + levelOneEntity.getObject().getLengths() + " not found");
+        }
+        extendedLengths.get().setAttributeType(SeqColExtendedDataEntity.AttributeType.lengths);
+
+        Optional<SeqColExtendedDataEntity> extendedNames = extendedDataService.getExtendedAttributeByDigest(levelOneEntity.getObject().getNames());
+        if (!extendedNames.isPresent()) {
+            throw new RuntimeException("Extended names data with digest: " + levelOneEntity.getObject().getNames() + " not found");
+        }
+        extendedNames.get().setAttributeType(SeqColExtendedDataEntity.AttributeType.names);
+
+        return Arrays.asList(
+                extendedSequences.get(),
+                extendedLengths.get(),
+                extendedNames.get()
+        );
+    }
+
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
@@ -31,7 +31,7 @@ public class SeqColLevelTwoService {
             System.out.println("EXCPETION: seqCol with digest: " + digest + "doesn't exists !");
             return Optional.empty();
         }
-        // 2 DATABASE LOOKUPS (1 RECURSIVE CALL)
+        // 2 DATABASE LOOKUPS
         List<SeqColExtendedDataEntity> extendedAttributes = getExtendedAttributes(levelOneEntity.get());
         SeqColLevelTwoEntity levelTwoEntity = new SeqColLevelTwoEntity();
         for (SeqColExtendedDataEntity extendedData: extendedAttributes) {

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -1,23 +1,39 @@
 package uk.ac.ebi.eva.evaseqcol.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import uk.ac.ebi.eva.evaseqcol.datasource.NCBISeqColDataSource;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
+import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
+import uk.ac.ebi.eva.evaseqcol.exception.duplicateSeqColException;
+import uk.ac.ebi.eva.evaseqcol.repo.SeqColLevelOneRepository;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
 public class SeqColService {
 
-    @Autowired
-    SeqColLevelOneService levelOneService;
+    private final NCBISeqColDataSource ncbiSeqColDataSource;
+    private final SeqColLevelOneService levelOneService;
+    private final SeqColExtendedDataService extendedDataService;
+    private final Logger logger = LoggerFactory.getLogger(SeqColService.class);
 
     @Autowired
-    SeqColExtendedDataService extendedDataService;
+    public SeqColService(NCBISeqColDataSource ncbiSeqColDataSource, SeqColLevelOneService levelOneService,
+                         SeqColExtendedDataService extendedDataService) {
+        this.ncbiSeqColDataSource = ncbiSeqColDataSource;
+        this.levelOneService = levelOneService;
+        this.extendedDataService = extendedDataService;
+    }
 
     @Transactional
     /**
@@ -28,5 +44,44 @@ public class SeqColService {
         extendedDataService.addAll(extendedSeqColDataList);
         // TODO: HANDLE EXCEPTIONS
         return Optional.of(levelOneEntity1.getDigest());
+    }
+
+
+    public SeqColEntity getSeqColByDigest(String digest, Integer level) {
+        // TODO: implement the join query to fetch the level 2 with one single db query
+        return null;
+    }
+    public void fetchAndInsertSeqCol(String accession, SeqColEntity.NamingConvention namingConvention) throws IOException {
+        Optional<List<SeqColExtendedDataEntity>> fetchExtendedDataEntities = ncbiSeqColDataSource.getSeqColExtendedDataListByAccession(
+                accession, namingConvention);
+        if (!fetchExtendedDataEntities.isPresent()) {
+            throw new SeqColNotFoundException(accession);
+        }
+        SeqColLevelOneEntity levelOneEntity = ncbiSeqColDataSource.constructSeqColLevelOne(
+                fetchExtendedDataEntities.get(), namingConvention);
+        insertSeqColL1AndL2(fetchExtendedDataEntities.get(), levelOneEntity);
+        logger.info("Successfully inserted seqCol for accession " + accession);
+    }
+
+    @Transactional
+    public void insertSeqColL1AndL2(List<SeqColExtendedDataEntity> seqColExtendedDataEntities,
+                                    SeqColLevelOneEntity levelOneEntity) {
+        if (isSeqColL1Present(levelOneEntity)) {
+            throw new duplicateSeqColException(levelOneEntity.getDigest());
+        } else {
+            levelOneService.addSequenceCollectionL1(levelOneEntity);
+            extendedDataService.addAll(seqColExtendedDataEntities);
+        }
+
+    }
+
+    private boolean isSeqColL1Present(SeqColLevelOneEntity levelOneEntity) {
+        Optional<SeqColLevelOneEntity> existingSeqCol = levelOneService.getSeqColLevelOneByDigest(levelOneEntity.getDigest());
+        return existingSeqCol.isPresent();
+    }
+    private boolean isSeqColExtDataPresent(SeqColExtendedDataEntity extendedDataEntity) {
+        Optional<SeqColExtendedDataEntity> existingSeqColExtData = extendedDataService.getExtendedAttributeByDigest(
+                extendedDataEntity.getDigest());
+        return existingSeqColExtData.isPresent();
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -56,8 +56,15 @@ public class SeqColService {
            return levelOneService.getSeqColLevelOneByDigest(digest);
        } else if (level == 2) {
             Optional<SeqColLevelOneEntity> seqColLevelOne = levelOneService.getSeqColLevelOneByDigest(digest);
+            if (seqColLevelOne.isPresent()) {
+                System.out.println("TEST 1");
+                System.out.println("DIGEST: "+seqColLevelOne.get().getDigest());
+                System.out.println("OBJECT: " + seqColLevelOne.get().getSeqColLevel1Object());
+            }
             SeqColLevelTwoEntity levelTwoEntity = new SeqColLevelTwoEntity().setDigest(digest);
             // Retrieving sequences
+           //-----------------TEST-------------------//
+           System.out.println(seqColLevelOne.get());
             String sequencesDigest = seqColLevelOne.get().getSeqColLevel1Object().getSequences();
             JSONExtData extendedSequences = extendedDataService.getSeqColExtendedDataEntityByDigest(sequencesDigest).get().getExtendedSeqColData();
            // Retrieving legnths

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -1,0 +1,32 @@
+package uk.ac.ebi.eva.evaseqcol.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class SeqColService {
+
+    @Autowired
+    SeqColLevelOneService levelOneService;
+
+    @Autowired
+    SeqColExtendedDataService extendedDataService;
+
+    @Transactional
+    /**
+     * Insert full sequence collection data (level 1 entity, and the exploded data entities)
+     * @return  The level 0 digest of the whole seqCol object*/
+    public Optional<String> addFullSequenceCollection(SeqColLevelOneEntity levelOneEntity, List<SeqColExtendedDataEntity> extendedSeqColDataList) {
+        SeqColLevelOneEntity levelOneEntity1 = levelOneService.addSequenceCollectionL1(levelOneEntity).get();
+        extendedDataService.addAll(extendedSeqColDataList);
+        // TODO: HANDLE EXCEPTIONS
+        return Optional.of(levelOneEntity1.getDigest());
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -11,7 +11,6 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
-import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.exception.duplicateSeqColException;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/utils/JSONExtData.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/utils/JSONExtData.java
@@ -31,7 +31,7 @@ public class JSONExtData implements Serializable {
     public String toString() {
         StringBuilder objectStr = new StringBuilder();
         objectStr.append("[");
-        if (onlyDigits(object.get(0).toString())) { // Lengths array, No quotes "..." delimiters. Eg: [1111, 222, 333]
+        if (onlyDigits(object.get(0).toString())) { // Lengths array, No quotes "...". Eg: [1111, 222, 333]
             for (int i=0; i<object.size()-1; i++) {
                objectStr.append(object.get(i));
                objectStr.append(",");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,5 +29,3 @@ asm.file.download.dir=/tmp
 spring.data.rest.detection-strategy=annotated
 
 spring.data.rest.basePath=/api
-
-spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,3 +29,5 @@ asm.file.download.dir=/tmp
 spring.data.rest.detection-strategy=annotated
 
 spring.data.rest.basePath=/api
+
+spring.jpa.properties.hibernate.format_sql=true

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBIAssemblySequenceDataSourceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBIAssemblySequenceDataSourceTest.java
@@ -26,7 +26,7 @@ class NCBIAssemblySequenceDataSourceTest {
     private NCBIAssemblySequenceDataSource dataSource;
 
     @Test
-    void getAssemblySequencesByAccession() throws IOException, NoSuchAlgorithmException {
+    void getAssemblySequencesByAccession() throws IOException {
         Optional<AssemblySequenceEntity> sequencesEntity = dataSource.getAssemblySequencesByAccession(GCA_ACCESSION);
         assertTrue(sequencesEntity.isPresent());
         List<SeqColSequenceEntity> sequenceList = sequencesEntity.get().getSequences();

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSourceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSourceTest.java
@@ -28,6 +28,6 @@ class NCBISeqColDataSourceTest {
         Optional<SeqColLevelOneEntity> levelOneEntity = ncbiSeqColDataSource.getSeqColL1ByAssemblyAccession(
                 GCA_ACCESSION, NAMING_CONVENTION);
         assertTrue(levelOneEntity.isPresent());
-        assertFalse(levelOneEntity.get().getObject().getSequences().isEmpty());
+        assertFalse(levelOneEntity.get().getSeqColLevel1Object().getSequences().isEmpty());
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSourceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSourceTest.java
@@ -1,0 +1,33 @@
+package uk.ac.ebi.eva.evaseqcol.datasource;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("seqcol")
+class NCBISeqColDataSourceTest {
+
+    private final String GCA_ACCESSION = "GCA_000146045.2";
+    private final SeqColEntity.NamingConvention NAMING_CONVENTION = SeqColEntity.NamingConvention.GENBANK;
+
+    @Autowired
+    private NCBISeqColDataSource ncbiSeqColDataSource;
+
+    @Test
+    void getSeqColL1ByAssemblyAccession() throws IOException {
+        Optional<SeqColLevelOneEntity> levelOneEntity = ncbiSeqColDataSource.getSeqColL1ByAssemblyAccession(
+                GCA_ACCESSION, NAMING_CONVENTION);
+        assertTrue(levelOneEntity.isPresent());
+        assertFalse(levelOneEntity.get().getObject().getSequences().isEmpty());
+    }
+}

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
@@ -12,20 +12,19 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblyReportReader;
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblyReportReaderFactory;
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblySequenceReader;
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblySequenceReaderFactory;
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblyEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.entities.ChromosomeEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
-import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
-import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
 import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -51,21 +50,24 @@ class SeqColExtendedDataServiceTest {
 
     private static final String GCA_ACCESSION = "GCA_000146045.2";
     //private static final String GCF_ACCESSION = "GCF_000001765.3";
-    private final boolean isScaffoldsEnabled = true;
-    private AssemblyEntity assemblyEntity;
-    private AssemblySequenceEntity assemblySequenceEntity;
-    private static BufferedReader sequencesReader;
-    private static InputStreamReader streamReaderSequences;
-    private static InputStream streamSequences;
+    private static InputStreamReader sequencesStreamReader;
+    private static InputStream sequencesStream;
 
-    private static BufferedReader reportReader;
-    private static InputStreamReader streamReaderReport;
-    private static InputStream streamReport;
+    private static InputStreamReader reportStreamReader;
+    private static InputStream reportStream;
 
     @Autowired
-    private SeqColExtendedDataService levelTwoService;
+    private NCBIAssemblyReportReaderFactory reportReaderFactory;
+    private NCBIAssemblyReportReader reportReader;
 
-    private ChecksumCalculator sha512Calculator;
+    @Autowired
+    private NCBIAssemblySequenceReaderFactory sequenceReaderFactory;
+    private NCBIAssemblySequenceReader sequenceReader;
+
+    @Autowired
+    private SeqColExtendedDataService extendedDataService;
+
+    private SHA512Calculator sha512Calculator = new SHA512Calculator();
 
     @Container
     static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15.2");
@@ -80,222 +82,31 @@ class SeqColExtendedDataServiceTest {
 
     @BeforeEach
     void setUp() throws FileNotFoundException {
-        streamSequences = new FileInputStream(
+        sequencesStream = new FileInputStream(
                 new File(SEQUENCES_FILE_PATH_1));
-        streamReaderSequences = new InputStreamReader(streamSequences);
-        sequencesReader = new BufferedReader(streamReaderSequences);
-        assemblySequenceEntity = new AssemblySequenceEntity()
-                .setInsdcAccession(GCA_ACCESSION);
+        sequencesStreamReader = new InputStreamReader(sequencesStream);
+        sequenceReader = sequenceReaderFactory.build(sequencesStreamReader, GCA_ACCESSION);
 
-        streamReport = new FileInputStream(
+        reportStream = new FileInputStream(
                 new File(REPORT_FILE_PATH_1));
-        streamReaderReport = new InputStreamReader(streamReport);
-        reportReader = new BufferedReader(streamReaderReport);
-        sha512Calculator = new SHA512Calculator();
+        reportStreamReader = new InputStreamReader(reportStream);
+        reportReader = reportReaderFactory.build(reportStreamReader);
     }
 
     @AfterEach
     void tearDown() throws IOException {
-        streamReport.close();
-        streamReaderReport.close();
-        streamSequences.close();
-        streamReaderSequences.close();
+        reportStream.close();
+        reportStreamReader.close();
+        sequencesStream.close();
+        sequencesStreamReader.close();
     }
 
-    void parseFile() throws IOException, NullPointerException {
-        if (sequencesReader == null){
-            throw new NullPointerException("Cannot use AssemblySequenceReader without having a valid InputStreamReader.");
-        }
-        ChecksumCalculator md5Calculator = new MD5Calculator();
-        if (assemblySequenceEntity == null){
-            assemblySequenceEntity = new AssemblySequenceEntity();
-        }
-        // Setting the accession of the whole assembly file
-        assemblySequenceEntity.setInsdcAccession(GCA_ACCESSION);
-        List<SeqColSequenceEntity> sequences = new LinkedList<>();
-        String line = sequencesReader.readLine();
-        while (line != null){
-            if (line.startsWith(">")){
-                SeqColSequenceEntity sequence = new SeqColSequenceEntity();
-                String refSeq = line.substring(1, line.indexOf(' '));
-                sequence.setRefseq(refSeq);
-                line = sequencesReader.readLine();
-                StringBuilder sequenceValue = new StringBuilder();
-                while (line != null && !line.startsWith(">")){
-                    // Looking for the sequence lines for this refseq
-                    sequenceValue.append(line);
-                    line = sequencesReader.readLine();
-                }
-                String md5checksum = md5Calculator.calculateChecksum(sequenceValue.toString().toUpperCase());
-                sequence.setSequenceMD5(md5checksum);
-                sequences.add(sequence);
-            }
-        }
-        assemblySequenceEntity.setSequences(sequences);
+    AssemblyEntity getAssemblyEntity() throws IOException {
+        return reportReader.getAssemblyEntity();
     }
 
-    void parseReport() throws IOException, NullPointerException {
-        if (reportReader == null) {
-            throw new NullPointerException("Cannot use AssemblyReportReader without having a valid InputStreamReader.");
-        }
-        String line = reportReader.readLine();
-        while (line != null) {
-            if (line.startsWith("# ")) {
-                if (assemblyEntity == null) {
-                    assemblyEntity = new AssemblyEntity();
-                }
-                parseAssemblyData(line);
-            } else if (!line.startsWith("#")) {
-                String[] columns = line.split("\t", -1);
-                if (columns.length >= 6 && (columns[5].equals("=") || columns[5].equals("<>")) &&
-                        (columns[4] != null && !columns[4].isEmpty() && !columns[4].equals("na"))) {
-                    if (columns[3].equals("Chromosome") && columns[1].equals("assembled-molecule")) {
-                        parseChromosomeLine(columns);
-                    } else if (isScaffoldsEnabled) {
-                        parseScaffoldLine(columns);
-                    }
-                }
-            }
-            line = reportReader.readLine();
-        }
-    }
-
-    void parseAssemblyData(String line) {
-        int tagEnd = line.indexOf(':');
-        if (tagEnd == -1) {
-            return;
-        }
-        String tag = line.substring(2, tagEnd);
-        String tagData = line.substring(tagEnd + 1).trim();
-        switch (tag) {
-            case "Assembly name": {
-                assemblyEntity.setName(tagData);
-                break;
-            }
-            case "Organism name": {
-                assemblyEntity.setOrganism(tagData);
-                break;
-            }
-            case "Taxid": {
-                assemblyEntity.setTaxid(Long.parseLong(tagData));
-                break;
-            }
-            case "GenBank assembly accession": {
-                assemblyEntity.setInsdcAccession(tagData);
-                break;
-            }
-            case "RefSeq assembly accession": {
-                assemblyEntity.setRefseq(tagData);
-                break;
-            }
-            case "RefSeq assembly and GenBank assemblies identical": {
-                assemblyEntity.setGenbankRefseqIdentical(tagData.equals("yes"));
-                break;
-            }
-        }
-    }
-
-    void parseChromosomeLine(String[] columns) {
-        ChromosomeEntity chromosomeEntity = new ChromosomeEntity();
-
-        chromosomeEntity.setGenbankSequenceName(columns[0]);
-        chromosomeEntity.setInsdcAccession(columns[4]);
-        if (columns[6] == null || columns[6].isEmpty() || columns[6].equals("na")) {
-            chromosomeEntity.setRefseq(null);
-        } else {
-            chromosomeEntity.setRefseq(columns[6]);
-        }
-
-        if (columns.length > 8) {
-            try {
-                Long seqLength = Long.parseLong(columns[8]);
-                chromosomeEntity.setSeqLength(seqLength);
-            } catch (NumberFormatException nfe) {
-
-            }
-        }
-
-        if (columns.length > 9 && !columns[9].equals("na")) {
-            chromosomeEntity.setUcscName(columns[9]);
-        }
-
-        if (assemblyEntity == null) {
-            assemblyEntity = new AssemblyEntity();
-        }
-        chromosomeEntity.setAssembly(this.assemblyEntity);
-        chromosomeEntity.setContigType(SequenceEntity.ContigType.CHROMOSOME);
-
-        List<ChromosomeEntity> chromosomes = this.assemblyEntity.getChromosomes();
-        if (chromosomes == null) {
-            chromosomes = new LinkedList<>();
-            assemblyEntity.setChromosomes(chromosomes);
-        }
-        chromosomes.add(chromosomeEntity);
-    }
-
-    void parseScaffoldLine(String[] columns) {
-        ChromosomeEntity scaffoldEntity = new ChromosomeEntity();
-
-        scaffoldEntity.setGenbankSequenceName(columns[0]);
-        scaffoldEntity.setInsdcAccession(columns[4]);
-        if (columns[6] == null || columns[6].isEmpty() || columns[6].equals("na")) {
-            scaffoldEntity.setRefseq(null);
-        } else {
-            scaffoldEntity.setRefseq(columns[6]);
-        }
-
-        if (columns.length > 8) {
-            try {
-                Long seqLength = Long.parseLong(columns[8]);
-                scaffoldEntity.setSeqLength(seqLength);
-            } catch (NumberFormatException nfe) {
-
-            }
-        }
-
-
-        if (columns.length >= 10) {
-            String ucscName = columns[9];
-            if (!ucscName.equals("na")) {
-                scaffoldEntity.setUcscName(ucscName);
-            }
-        }
-
-        if (assemblyEntity == null) {
-            assemblyEntity = new AssemblyEntity();
-        }
-        scaffoldEntity.setAssembly(this.assemblyEntity);
-        scaffoldEntity.setContigType(SequenceEntity.ContigType.SCAFFOLD);
-
-        List<ChromosomeEntity> scaffolds = this.assemblyEntity.getChromosomes();
-        if (scaffolds == null) {
-            scaffolds = new LinkedList<>();
-            assemblyEntity.setChromosomes(scaffolds);
-        }
-        scaffolds.add(scaffoldEntity);
-    }
-
-
-    @Test
-    void    getAssemblyReportReader() throws IOException {
-        System.out.println("READY REPORT 2 ?" + reportReader.ready());
-        assertTrue(reportReader.ready());
-    }
-
-    @Test
-    void getAssemblySequencesReader() throws IOException {
-        assertTrue(sequencesReader.ready());
-    }
-
-    @Test
-    void getAssemblyReportAndSequences() throws IOException {
-        parseReport();
-        assertNotNull(assemblyEntity);
-        assertTrue(assemblyEntity.getChromosomes().size() > 0);
-        parseFile();
-        assertNotNull(assemblySequenceEntity);
-        assertTrue(assemblySequenceEntity.getSequences().size() > 0);
-        assertEquals(assemblySequenceEntity.getSequences().size(), assemblyEntity.getChromosomes().size());
+    AssemblySequenceEntity getAssemblySequenceEntity() throws IOException {
+        return sequenceReader.getAssemblySequencesEntity();
     }
 
     /**
@@ -360,33 +171,22 @@ class SeqColExtendedDataServiceTest {
         return seqColSequencesObject;
     }
 
-    /**
-     * Construct and return a Level Two (with exploded data) SeqCol entity out of the given assemblyEntity and the
-     * assemblySequencesEntity*/
-    SeqColLevelTwoEntity constructSeqColLevelTwo(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
-                                                 SeqColEntity.NamingConvention convention, String accession) throws IOException {
-        SeqColLevelTwoEntity seqColLevelTwo = new SeqColLevelTwoEntity();
-        SeqColExtendedDataEntity extendedNamesData = constructSeqColNamesObject(assemblyEntity, convention);
-        SeqColExtendedDataEntity extendedLengthsData = constructSeqColLengthsObject(assemblyEntity);
-        SeqColExtendedDataEntity extendedSequencesData = constructSeqColSequencesObject(assemblySequenceEntity);
-        seqColLevelTwo.setNames(extendedNamesData.getExtendedSeqColData().getObject());
-        seqColLevelTwo.setLengths(extendedLengthsData.getExtendedSeqColData().getObject());
-        seqColLevelTwo.setSequences(extendedSequencesData.getExtendedSeqColData().getObject());
-        return seqColLevelTwo;
-    }
-
     @Test
     /**
      * Adding multiple seqCol extended data objects*/
     void addSeqColExtendedData() throws IOException {
-        parseReport();
-        parseFile();
+        AssemblyEntity assemblyEntity = getAssemblyEntity();
+        AssemblySequenceEntity assemblySequenceEntity = getAssemblySequenceEntity();
         assertNotNull(assemblyEntity);
         assertEquals(assemblySequenceEntity.getSequences().size(), assemblyEntity.getChromosomes().size());
-        SeqColExtendedDataEntity seqColNamesObject = constructSeqColLengthsObject(assemblyEntity);
-        assertNotNull(seqColNamesObject);
-        assertNotNull(seqColNamesObject.getDigest());
-        Optional<SeqColExtendedDataEntity> fetchEntity = levelTwoService.addSeqColExtendedData(seqColNamesObject);
-        assertTrue(fetchEntity.isPresent());
+        SeqColExtendedDataEntity seqColLengthsObject = constructSeqColLengthsObject(assemblyEntity);
+        SeqColExtendedDataEntity seqColNamesObject = constructSeqColNamesObject(assemblyEntity, SeqColEntity.NamingConvention.GENBANK);
+        SeqColExtendedDataEntity seqColSequencesObject = constructSeqColSequencesObject(assemblySequenceEntity);
+        Optional<SeqColExtendedDataEntity> fetchNamesEntity = extendedDataService.addSeqColExtendedData(seqColLengthsObject);
+        Optional<SeqColExtendedDataEntity> fetchLengthsEntity = extendedDataService.addSeqColExtendedData(seqColNamesObject);
+        Optional<SeqColExtendedDataEntity> fetchSequencesEntity = extendedDataService.addSeqColExtendedData(seqColSequencesObject);
+        assertTrue(fetchNamesEntity.isPresent());
+        assertTrue(fetchLengthsEntity.isPresent());
+        assertTrue(fetchSequencesEntity.isPresent());
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
@@ -17,6 +17,7 @@ import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.ChromosomeEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
@@ -277,7 +277,7 @@ class SeqColExtendedDataServiceTest {
 
 
     @Test
-    void getAssemblyReportReader() throws IOException {
+    void    getAssemblyReportReader() throws IOException {
         System.out.println("READY REPORT 2 ?" + reportReader.ready());
         assertTrue(reportReader.ready());
     }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
@@ -360,6 +360,21 @@ class SeqColExtendedDataServiceTest {
         return seqColSequencesObject;
     }
 
+    /**
+     * Construct and return a Level Two (with exploded data) SeqCol entity out of the given assemblyEntity and the
+     * assemblySequencesEntity*/
+    SeqColLevelTwoEntity constructSeqColLevelTwo(AssemblyEntity assemblyEntity, AssemblySequenceEntity assemblySequenceEntity,
+                                                 SeqColEntity.NamingConvention convention, String accession) throws IOException {
+        SeqColLevelTwoEntity seqColLevelTwo = new SeqColLevelTwoEntity();
+        SeqColExtendedDataEntity extendedNamesData = constructSeqColNamesObject(assemblyEntity, convention);
+        SeqColExtendedDataEntity extendedLengthsData = constructSeqColLengthsObject(assemblyEntity);
+        SeqColExtendedDataEntity extendedSequencesData = constructSeqColSequencesObject(assemblySequenceEntity);
+        seqColLevelTwo.setNames(extendedNamesData.getObject().getObject());
+        seqColLevelTwo.setLengths(extendedLengthsData.getObject().getObject());
+        seqColLevelTwo.setSequences(extendedSequencesData.getObject().getObject());
+        return seqColLevelTwo;
+    }
+
     @Test
     /**
      * Adding multiple seqCol extended data objects*/

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
@@ -21,8 +21,8 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
-import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
 import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
+import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 
 import java.io.BufferedReader;
@@ -65,7 +65,7 @@ class SeqColExtendedDataServiceTest {
     @Autowired
     private SeqColExtendedDataService levelTwoService;
 
-    private DigestCalculator digestCalculator;
+    private ChecksumCalculator sha512Calculator;
 
     @Container
     static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15.2");
@@ -91,7 +91,7 @@ class SeqColExtendedDataServiceTest {
                 new File(REPORT_FILE_PATH_1));
         streamReaderReport = new InputStreamReader(streamReport);
         reportReader = new BufferedReader(streamReaderReport);
-        digestCalculator = new DigestCalculator();
+        sha512Calculator = new SHA512Calculator();
     }
 
     @AfterEach
@@ -322,7 +322,7 @@ class SeqColExtendedDataServiceTest {
 
         seqColNamesArray.setObject(namesList);
         seqColNamesObject.setExtendedSeqColData(seqColNamesArray);
-        seqColNamesObject.setDigest(digestCalculator.getSha512Digest(seqColNamesArray.toString()));
+        seqColNamesObject.setDigest(sha512Calculator.calculateChecksum(seqColNamesArray.toString()));
         return seqColNamesObject;
     }
 
@@ -339,13 +339,13 @@ class SeqColExtendedDataServiceTest {
         }
         seqColLengthsArray.setObject(lengthsList);
         seqColLengthsObject.setExtendedSeqColData(seqColLengthsArray);
-        seqColLengthsObject.setDigest(digestCalculator.getSha512Digest(seqColLengthsArray.toString()));
+        seqColLengthsObject.setDigest(sha512Calculator.calculateChecksum(seqColLengthsArray.toString()));
         return seqColLengthsObject;
     }
 
     /**
      * Return the seqCol sequences array object*/
-    public SeqColExtendedDataEntity constructSeqColSequencesObject(AssemblySequenceEntity assemblySequenceEntity) throws IOException {
+    public SeqColExtendedDataEntity constructSeqColSequencesObject(AssemblySequenceEntity assemblySequenceEntity){
         SeqColExtendedDataEntity seqColSequencesObject = new SeqColExtendedDataEntity().setAttributeType(
                 SeqColExtendedDataEntity.AttributeType.sequences);
         JSONExtData seqColSequencesArray = new JSONExtData();
@@ -356,7 +356,7 @@ class SeqColExtendedDataServiceTest {
         }
         seqColSequencesArray.setObject(sequencesList);
         seqColSequencesObject.setExtendedSeqColData(seqColSequencesArray);
-        seqColSequencesObject.setDigest(digestCalculator.getSha512Digest(seqColSequencesArray.toString()));
+        seqColSequencesObject.setDigest(sha512Calculator.calculateChecksum(seqColSequencesArray.toString()));
         return seqColSequencesObject;
     }
 
@@ -369,9 +369,9 @@ class SeqColExtendedDataServiceTest {
         SeqColExtendedDataEntity extendedNamesData = constructSeqColNamesObject(assemblyEntity, convention);
         SeqColExtendedDataEntity extendedLengthsData = constructSeqColLengthsObject(assemblyEntity);
         SeqColExtendedDataEntity extendedSequencesData = constructSeqColSequencesObject(assemblySequenceEntity);
-        seqColLevelTwo.setNames(extendedNamesData.getObject().getObject());
-        seqColLevelTwo.setLengths(extendedLengthsData.getObject().getObject());
-        seqColLevelTwo.setSequences(extendedSequencesData.getObject().getObject());
+        seqColLevelTwo.setNames(extendedNamesData.getExtendedSeqColData().getObject());
+        seqColLevelTwo.setLengths(extendedLengthsData.getExtendedSeqColData().getObject());
+        seqColLevelTwo.setSequences(extendedSequencesData.getExtendedSeqColData().getObject());
         return seqColLevelTwo;
     }
 

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneServiceTest.java
@@ -12,27 +12,24 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblyReportReader;
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblyReportReaderFactory;
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblySequenceReader;
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblySequenceReaderFactory;
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblyEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.entities.ChromosomeEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
-import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
 import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
-import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,16 +48,19 @@ class SeqColLevelOneServiceTest {
     //private final String SEQUENCES_FILE_PATH_2 = "src/test/resources/GCF_000001765.3_genome_sequence.fna";
 
     //private static final String GCF_ACCESSION = "GCF_000001765.3";
-    private final boolean isScaffoldsEnabled = true;
-    private AssemblyEntity assemblyEntity;
-    private AssemblySequenceEntity assemblySequenceEntity;
-    private static BufferedReader sequencesReader;
-    private static InputStreamReader streamReaderSequences;
-    private static InputStream streamSequences;
+    private static InputStreamReader sequencesStreamReader;
+    private static InputStream sequencesStream;
 
-    private static BufferedReader reportReader;
-    private static InputStreamReader streamReaderReport;
-    private static InputStream streamReport;
+    private static InputStreamReader reportStreamReader;
+    private static InputStream reportStream;
+
+    @Autowired
+    private NCBIAssemblyReportReaderFactory reportReaderFactory;
+    private NCBIAssemblyReportReader reportReader;
+
+    @Autowired
+    private NCBIAssemblySequenceReaderFactory sequenceReaderFactory;
+    private NCBIAssemblySequenceReader sequenceReader;
 
     @Autowired
     private SeqColExtendedDataService seqColExtendedDataService;
@@ -68,7 +68,7 @@ class SeqColLevelOneServiceTest {
     @Autowired
     private SeqColLevelOneService levelOneService;
 
-    private DigestCalculator digestCalculator;
+    private final DigestCalculator digestCalculator = new DigestCalculator();
 
     @Container
     static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15.2");
@@ -83,201 +83,32 @@ class SeqColLevelOneServiceTest {
 
     @BeforeEach
     void setUp() throws FileNotFoundException {
-        streamSequences = new FileInputStream(
+        sequencesStream = new FileInputStream(
                 new File(SEQUENCES_FILE_PATH_1));
-        streamReaderSequences = new InputStreamReader(streamSequences);
-        sequencesReader = new BufferedReader(streamReaderSequences);
-        assemblySequenceEntity = new AssemblySequenceEntity()
-                .setInsdcAccession(GCA_ACCESSION);
+        sequencesStreamReader = new InputStreamReader(sequencesStream);
+        sequenceReader = sequenceReaderFactory.build(sequencesStreamReader, GCA_ACCESSION);
 
-        streamReport = new FileInputStream(
+        reportStream = new FileInputStream(
                 new File(REPORT_FILE_PATH_1));
-        streamReaderReport = new InputStreamReader(streamReport);
-        reportReader = new BufferedReader(streamReaderReport);
-        digestCalculator = new DigestCalculator();
+        reportStreamReader = new InputStreamReader(reportStream);
+        reportReader = reportReaderFactory.build(reportStreamReader);
     }
 
     @AfterEach
     void tearDown() throws IOException {
-        streamReport.close();
-        streamReaderReport.close();
-        streamSequences.close();
-        streamReaderSequences.close();
+        reportStream.close();
+        reportStreamReader.close();
+        sequencesStream.close();
+        sequencesStreamReader.close();
     }
 
-    void parseFile() throws IOException, NullPointerException {
-        if (sequencesReader == null){
-            throw new NullPointerException("Cannot use AssemblySequenceReader without having a valid InputStreamReader.");
-        }
-        ChecksumCalculator md5Calculator = new MD5Calculator();
-        if (assemblySequenceEntity == null){
-            assemblySequenceEntity = new AssemblySequenceEntity();
-        }
-        // Setting the accession of the whole assembly file
-        assemblySequenceEntity.setInsdcAccession(GCA_ACCESSION);
-        List<SeqColSequenceEntity> sequences = new LinkedList<>();
-        String line = sequencesReader.readLine();
-        while (line != null){
-            if (line.startsWith(">")){
-                SeqColSequenceEntity sequence = new SeqColSequenceEntity();
-                String refSeq = line.substring(1, line.indexOf(' '));
-                sequence.setRefseq(refSeq);
-                line = sequencesReader.readLine();
-                StringBuilder sequenceValue = new StringBuilder();
-                while (line != null && !line.startsWith(">")){
-                    // Looking for the sequence lines for this refseq
-                    sequenceValue.append(line);
-                    line = sequencesReader.readLine();
-                }
-                String md5checksum = md5Calculator.calculateChecksum(sequenceValue.toString().toUpperCase());
-                sequence.setSequenceMD5(md5checksum);
-                sequences.add(sequence);
-            }
-        }
-        assemblySequenceEntity.setSequences(sequences);
+    AssemblyEntity getAssemblyEntity() throws IOException {
+        return reportReader.getAssemblyEntity();
     }
 
-    void parseReport() throws IOException, NullPointerException {
-        if (reportReader == null) {
-            throw new NullPointerException("Cannot use AssemblyReportReader without having a valid InputStreamReader.");
-        }
-        String line = reportReader.readLine();
-        while (line != null) {
-            if (line.startsWith("# ")) {
-                if (assemblyEntity == null) {
-                    assemblyEntity = new AssemblyEntity();
-                }
-                parseAssemblyData(line);
-            } else if (!line.startsWith("#")) {
-                String[] columns = line.split("\t", -1);
-                if (columns.length >= 6 && (columns[5].equals("=") || columns[5].equals("<>")) &&
-                        (columns[4] != null && !columns[4].isEmpty() && !columns[4].equals("na"))) {
-                    if (columns[3].equals("Chromosome") && columns[1].equals("assembled-molecule")) {
-                        parseChromosomeLine(columns);
-                    } else if (isScaffoldsEnabled) {
-                        parseScaffoldLine(columns);
-                    }
-                }
-            }
-            line = reportReader.readLine();
-        }
+    AssemblySequenceEntity getAssemblySequenceEntity() throws IOException {
+        return sequenceReader.getAssemblySequencesEntity();
     }
-
-    void parseAssemblyData(String line) {
-        int tagEnd = line.indexOf(':');
-        if (tagEnd == -1) {
-            return;
-        }
-        String tag = line.substring(2, tagEnd);
-        String tagData = line.substring(tagEnd + 1).trim();
-        switch (tag) {
-            case "Assembly name": {
-                assemblyEntity.setName(tagData);
-                break;
-            }
-            case "Organism name": {
-                assemblyEntity.setOrganism(tagData);
-                break;
-            }
-            case "Taxid": {
-                assemblyEntity.setTaxid(Long.parseLong(tagData));
-                break;
-            }
-            case "GenBank assembly accession": {
-                assemblyEntity.setInsdcAccession(tagData);
-                break;
-            }
-            case "RefSeq assembly accession": {
-                assemblyEntity.setRefseq(tagData);
-                break;
-            }
-            case "RefSeq assembly and GenBank assemblies identical": {
-                assemblyEntity.setGenbankRefseqIdentical(tagData.equals("yes"));
-                break;
-            }
-        }
-    }
-
-    void parseChromosomeLine(String[] columns) {
-        ChromosomeEntity chromosomeEntity = new ChromosomeEntity();
-
-        chromosomeEntity.setGenbankSequenceName(columns[0]);
-        chromosomeEntity.setInsdcAccession(columns[4]);
-        if (columns[6] == null || columns[6].isEmpty() || columns[6].equals("na")) {
-            chromosomeEntity.setRefseq(null);
-        } else {
-            chromosomeEntity.setRefseq(columns[6]);
-        }
-
-        if (columns.length > 8) {
-            try {
-                Long seqLength = Long.parseLong(columns[8]);
-                chromosomeEntity.setSeqLength(seqLength);
-            } catch (NumberFormatException nfe) {
-
-            }
-        }
-
-        if (columns.length > 9 && !columns[9].equals("na")) {
-            chromosomeEntity.setUcscName(columns[9]);
-        }
-
-        if (assemblyEntity == null) {
-            assemblyEntity = new AssemblyEntity();
-        }
-        chromosomeEntity.setAssembly(this.assemblyEntity);
-        chromosomeEntity.setContigType(SequenceEntity.ContigType.CHROMOSOME);
-
-        List<ChromosomeEntity> chromosomes = this.assemblyEntity.getChromosomes();
-        if (chromosomes == null) {
-            chromosomes = new LinkedList<>();
-            assemblyEntity.setChromosomes(chromosomes);
-        }
-        chromosomes.add(chromosomeEntity);
-    }
-
-    void parseScaffoldLine(String[] columns) {
-        ChromosomeEntity scaffoldEntity = new ChromosomeEntity();
-
-        scaffoldEntity.setGenbankSequenceName(columns[0]);
-        scaffoldEntity.setInsdcAccession(columns[4]);
-        if (columns[6] == null || columns[6].isEmpty() || columns[6].equals("na")) {
-            scaffoldEntity.setRefseq(null);
-        } else {
-            scaffoldEntity.setRefseq(columns[6]);
-        }
-
-        if (columns.length > 8) {
-            try {
-                Long seqLength = Long.parseLong(columns[8]);
-                scaffoldEntity.setSeqLength(seqLength);
-            } catch (NumberFormatException nfe) {
-
-            }
-        }
-
-
-        if (columns.length >= 10) {
-            String ucscName = columns[9];
-            if (!ucscName.equals("na")) {
-                scaffoldEntity.setUcscName(ucscName);
-            }
-        }
-
-        if (assemblyEntity == null) {
-            assemblyEntity = new AssemblyEntity();
-        }
-        scaffoldEntity.setAssembly(this.assemblyEntity);
-        scaffoldEntity.setContigType(SequenceEntity.ContigType.SCAFFOLD);
-
-        List<ChromosomeEntity> scaffolds = this.assemblyEntity.getChromosomes();
-        if (scaffolds == null) {
-            scaffolds = new LinkedList<>();
-            assemblyEntity.setChromosomes(scaffolds);
-        }
-        scaffolds.add(scaffoldEntity);
-    }
-
 
     /**
      * Construct a seqCol level 1 entity out of three seqCol level 2 entities that
@@ -308,10 +139,10 @@ class SeqColLevelOneServiceTest {
 
     @Test
     void addSequenceCollectionL1() throws IOException {
-        parseReport();
-        parseFile();
+        AssemblyEntity assemblyEntity = getAssemblyEntity();
+        AssemblySequenceEntity assemblySequenceEntity = getAssemblySequenceEntity();
         List<SeqColExtendedDataEntity> extendedDataEntities = seqColExtendedDataService.constructExtendedSeqColDataList(
-                assemblyEntity, assemblySequenceEntity, SeqColEntity.NamingConvention.GENBANK, GCA_ACCESSION
+                assemblyEntity, assemblySequenceEntity, SeqColEntity.NamingConvention.GENBANK
         ); // Contains the list of names, lengths and sequences exploded
 
         SeqColLevelOneEntity levelOneEntity = constructSeqColLevelOne(extendedDataEntities, SeqColEntity.NamingConvention.GENBANK);

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneServiceTest.java
@@ -6,6 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblyEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
@@ -36,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("seqcol")
+@Testcontainers
 class SeqColLevelOneServiceTest {
 
     private final String REPORT_FILE_PATH_1 = "src/test/resources/GCA_000146045.2_R64_assembly_report.txt";
@@ -63,6 +69,17 @@ class SeqColLevelOneServiceTest {
     private SeqColLevelOneService levelOneService;
 
     private DigestCalculator digestCalculator;
+
+    @Container
+    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15.2");
+
+    @DynamicPropertySource
+    static void dataSourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
+        registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "update");
+    }
 
     @BeforeEach
     void setUp() throws FileNotFoundException {

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneServiceTest.java
@@ -16,7 +16,7 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
-import uk.ac.ebi.eva.evaseqcol.refget.DigestCalculator;
+import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
 import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
 
@@ -282,8 +282,8 @@ class SeqColLevelOneServiceTest {
                     break;
             }
         }
-        levelOneEntity.setObject(jsonLevelOne);
-        String digest0 = digestCalculator.generateDigest(levelOneEntity.toString());
+        levelOneEntity.setSeqColLevel1Object(jsonLevelOne);
+        String digest0 = digestCalculator.getSha512Digest(levelOneEntity.toString());
         levelOneEntity.setDigest(digest0);
         levelOneEntity.setNamingConvention(convention);
         return levelOneEntity;

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoServiceTest.java
@@ -1,0 +1,29 @@
+package uk.ac.ebi.eva.evaseqcol.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("seqcol")
+class SeqColLevelTwoServiceTest {
+
+    private String LEVEL_0_DIGEST = "Y2ujWD8fTeC86uKbL22N2jyMYrcX0cN0";
+
+    @Autowired
+    private SeqColLevelTwoService levelTwoService;
+
+    @Test
+    void getSeqColLevelTwoByDigest() {
+        Optional<SeqColLevelTwoEntity> levelTwoEntity = levelTwoService.getSeqColLevelTwoByDigest(LEVEL_0_DIGEST);
+        assertTrue(levelTwoEntity.isPresent());
+        assertTrue(levelTwoEntity.get().getLengths().size() > 0);
+    }
+}

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoServiceTest.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.eva.evaseqcol.service;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,6 +22,8 @@ class SeqColLevelTwoServiceTest {
     private SeqColLevelTwoService levelTwoService;
 
     @Test
+    @Disabled
+    // Disabled on GitHub. You can enable it locally when you have the seqCol with the given digest saved
     void getSeqColLevelTwoByDigest() {
         Optional<SeqColLevelTwoEntity> levelTwoEntity = levelTwoService.getSeqColLevelTwoByDigest(LEVEL_0_DIGEST);
         assertTrue(levelTwoEntity.isPresent());

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -270,4 +270,5 @@ class SeqColServiceTest {
         assertTrue(resultDigest.isPresent());
         System.out.println("RESULT DIGEST: " + resultDigest);
     }
+
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -22,6 +22,7 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
+import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColException;
 import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
 import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
 import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
@@ -299,4 +300,12 @@ class SeqColServiceTest {
         assertTrue(levelTwoEntity.isPresent());
     }
 
+    @Test
+    void fetchAndInsertSeqColByAssemblyAccessionTesst() throws IOException {
+        try {
+            seqColService.fetchAndInsertSeqColByAssemblyAccession(GCA_ACCESSION, SeqColEntity.NamingConvention.GENBANK);
+        } catch (DuplicateSeqColException e) {
+            System.out.println(e.getMessage());
+        }
+    }
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -2,10 +2,16 @@ package uk.ac.ebi.eva.evaseqcol.service;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblyEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
@@ -35,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("seqcol")
+@Testcontainers
 class SeqColServiceTest {
 
     private final String REPORT_FILE_PATH_1 = "src/test/resources/GCA_000146045.2_R64_assembly_report.txt";
@@ -60,6 +67,17 @@ class SeqColServiceTest {
     @Autowired
     private SeqColService seqColService;
     private DigestCalculator digestCalculator;
+
+    @Container
+    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15.2");
+
+    @DynamicPropertySource
+    static void dataSourceProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
+        registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "update");
+    }
 
     @BeforeEach
     void setUp() throws FileNotFoundException {
@@ -274,6 +292,7 @@ class SeqColServiceTest {
     }
 
     @Test
+    @Disabled  // Disabled on GitHub. You can enable it locally when you have the seqCol with the given digest saved
     void getSeqColByDigestAndLevelTest() throws IOException {
         String TEST_DIGEST = addSequenceCollection();
         System.out.println("TEST DIGEST:" + TEST_DIGEST);

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("seqcol")
-@Testcontainers
+//@Testcontainers
 class SeqColServiceTest {
 
     private final String REPORT_FILE_PATH_1 = "src/test/resources/GCA_000146045.2_R64_assembly_report.txt";
@@ -68,7 +68,7 @@ class SeqColServiceTest {
     private SeqColService seqColService;
     private DigestCalculator digestCalculator;
 
-    @Container
+   /* @Container
     static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15.2");
 
     @DynamicPropertySource
@@ -77,7 +77,7 @@ class SeqColServiceTest {
         registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
         registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "update");
-    }
+    }*/
 
     @BeforeEach
     void setUp() throws FileNotFoundException {
@@ -277,7 +277,7 @@ class SeqColServiceTest {
     }
 
     @Test
-    String addSequenceCollection() throws IOException {
+    void addSequenceCollection() throws IOException {
         parseFile();
         parseReport();
         List<SeqColExtendedDataEntity> extendedDataEntities = extendedDataService.constructExtendedSeqColDataList(
@@ -288,17 +288,14 @@ class SeqColServiceTest {
         Optional<String> resultDigest = seqColService.addFullSequenceCollection(levelOneEntity, extendedDataEntities);
         assertTrue(resultDigest.isPresent());
         System.out.println("RESULT DIGEST: " + resultDigest);
-        return resultDigest.get();
     }
 
     @Test
-    @Disabled  // Disabled on GitHub. You can enable it locally when you have the seqCol with the given digest saved
-    void getSeqColByDigestAndLevelTest() throws IOException {
-        String TEST_DIGEST = addSequenceCollection();
-        System.out.println("TEST DIGEST:" + TEST_DIGEST);
-        Optional<SeqColLevelOneEntity> levelOneEntity = (Optional<SeqColLevelOneEntity>) seqColService.getSeqColByDigestAndLevel(TEST_DIGEST, 1);
+    @Disabled // Disabled on GitHub. Enable it when you have a seqcol already saved in your local db with the given digest
+    void getSeqColByDigestAndLevelTest() {
+        Optional<SeqColLevelOneEntity> levelOneEntity = (Optional<SeqColLevelOneEntity>) seqColService.getSeqColByDigestAndLevel("7eldYm-sjycc1MDEVSI5jmuNac4BO-eN", 1);
         assertTrue(levelOneEntity.isPresent());
-        Optional<SeqColLevelTwoEntity> levelTwoEntity = (Optional<SeqColLevelTwoEntity>) seqColService.getSeqColByDigestAndLevel(TEST_DIGEST, 2);
+        Optional<SeqColLevelTwoEntity> levelTwoEntity = (Optional<SeqColLevelTwoEntity>) seqColService.getSeqColByDigestAndLevel("7eldYm-sjycc1MDEVSI5jmuNac4BO-eN", 2);
         assertTrue(levelTwoEntity.isPresent());
     }
 

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -3,7 +3,10 @@ package uk.ac.ebi.eva.evaseqcol.service;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -13,34 +16,30 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblyReportReader;
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblyReportReaderFactory;
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblySequenceReader;
+import uk.ac.ebi.eva.evaseqcol.dus.NCBIAssemblySequenceReaderFactory;
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblyEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.entities.ChromosomeEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
-import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColException;
-import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
-import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
-import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @ActiveProfiles("seqcol")
 @Testcontainers
 class SeqColServiceTest {
@@ -48,16 +47,22 @@ class SeqColServiceTest {
     private final String REPORT_FILE_PATH_1 = "src/test/resources/GCA_000146045.2_R64_assembly_report.txt";
     private final String SEQUENCES_FILE_PATH_1 = "src/test/resources/GCA_000146045.2_genome_sequence.fna";
     private static final String GCA_ACCESSION = "GCA_000146045.2";
-    private final boolean isScaffoldsEnabled = true;
-    private AssemblyEntity assemblyEntity;
-    private AssemblySequenceEntity assemblySequenceEntity;
-    private static BufferedReader sequencesReader;
-    private static InputStreamReader streamReaderSequences;
-    private static InputStream streamSequences;
 
-    private static BufferedReader reportReader;
-    private static InputStreamReader streamReaderReport;
-    private static InputStream streamReport;
+    private final String RESULT_DIGEST = "7eldYm-sjycc1MDEVSI5jmuNac4BO-eN";
+    private static InputStreamReader sequencesStreamReader;
+    private static InputStream sequencesStream;
+
+    private static InputStreamReader reportStreamReader;
+    private static InputStream reportStream;
+
+    @Autowired
+    private NCBIAssemblyReportReaderFactory reportReaderFactory;
+    private NCBIAssemblyReportReader reportReader;
+
+    @Autowired
+    private NCBIAssemblySequenceReaderFactory sequenceReaderFactory;
+    private NCBIAssemblySequenceReader sequenceReader;
+
 
     @Autowired
     private SeqColLevelOneService levelOneService;
@@ -67,7 +72,7 @@ class SeqColServiceTest {
 
     @Autowired
     private SeqColService seqColService;
-    private DigestCalculator digestCalculator;
+
 
     @Container
     static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15.2");
@@ -82,230 +87,53 @@ class SeqColServiceTest {
 
     @BeforeEach
     void setUp() throws FileNotFoundException {
-        streamSequences = new FileInputStream(
+        sequencesStream = new FileInputStream(
                 new File(SEQUENCES_FILE_PATH_1));
-        streamReaderSequences = new InputStreamReader(streamSequences);
-        sequencesReader = new BufferedReader(streamReaderSequences);
-        assemblySequenceEntity = new AssemblySequenceEntity()
-                .setInsdcAccession(GCA_ACCESSION);
+        sequencesStreamReader = new InputStreamReader(sequencesStream);
+        sequenceReader = sequenceReaderFactory.build(sequencesStreamReader, GCA_ACCESSION);
 
-        streamReport = new FileInputStream(
+        reportStream = new FileInputStream(
                 new File(REPORT_FILE_PATH_1));
-        streamReaderReport = new InputStreamReader(streamReport);
-        reportReader = new BufferedReader(streamReaderReport);
-        digestCalculator = new DigestCalculator();
+        reportStreamReader = new InputStreamReader(reportStream);
+        reportReader = reportReaderFactory.build(reportStreamReader);
     }
 
     @AfterEach
     void tearDown() throws IOException {
-        streamReport.close();
-        streamReaderReport.close();
-        streamSequences.close();
-        streamReaderSequences.close();
+        reportStream.close();
+        reportStreamReader.close();
+        sequencesStream.close();
+        sequencesStreamReader.close();
     }
 
-    void parseFile() throws IOException, NullPointerException {
-        if (sequencesReader == null){
-            throw new NullPointerException("Cannot use AssemblySequenceReader without having a valid InputStreamReader.");
-        }
-        ChecksumCalculator md5Calculator = new MD5Calculator();
-        if (assemblySequenceEntity == null){
-            assemblySequenceEntity = new AssemblySequenceEntity();
-        }
-        // Setting the accession of the whole assembly file
-        assemblySequenceEntity.setInsdcAccession(GCA_ACCESSION);
-        List<SeqColSequenceEntity> sequences = new LinkedList<>();
-        String line = sequencesReader.readLine();
-        while (line != null){
-            if (line.startsWith(">")){
-                SeqColSequenceEntity sequence = new SeqColSequenceEntity();
-                String refSeq = line.substring(1, line.indexOf(' '));
-                sequence.setRefseq(refSeq);
-                line = sequencesReader.readLine();
-                StringBuilder sequenceValue = new StringBuilder();
-                while (line != null && !line.startsWith(">")){
-                    // Looking for the sequence lines for this refseq
-                    sequenceValue.append(line);
-                    line = sequencesReader.readLine();
-                }
-                String md5checksum = md5Calculator.calculateChecksum(sequenceValue.toString().toUpperCase());
-                sequence.setSequenceMD5(md5checksum);
-                sequences.add(sequence);
-            }
-        }
-        assemblySequenceEntity.setSequences(sequences);
+    AssemblyEntity getAssemblyEntity() throws IOException {
+        return reportReader.getAssemblyEntity();
     }
 
-    void parseReport() throws IOException, NullPointerException {
-        if (reportReader == null) {
-            throw new NullPointerException("Cannot use AssemblyReportReader without having a valid InputStreamReader.");
-        }
-        String line = reportReader.readLine();
-        while (line != null) {
-            if (line.startsWith("# ")) {
-                if (assemblyEntity == null) {
-                    assemblyEntity = new AssemblyEntity();
-                }
-                parseAssemblyData(line);
-            } else if (!line.startsWith("#")) {
-                String[] columns = line.split("\t", -1);
-                if (columns.length >= 6 && (columns[5].equals("=") || columns[5].equals("<>")) &&
-                        (columns[4] != null && !columns[4].isEmpty() && !columns[4].equals("na"))) {
-                    if (columns[3].equals("Chromosome") && columns[1].equals("assembled-molecule")) {
-                        parseChromosomeLine(columns);
-                    } else if (isScaffoldsEnabled) {
-                        parseScaffoldLine(columns);
-                    }
-                }
-            }
-            line = reportReader.readLine();
-        }
-    }
-
-    void parseAssemblyData(String line) {
-        int tagEnd = line.indexOf(':');
-        if (tagEnd == -1) {
-            return;
-        }
-        String tag = line.substring(2, tagEnd);
-        String tagData = line.substring(tagEnd + 1).trim();
-        switch (tag) {
-            case "Assembly name": {
-                assemblyEntity.setName(tagData);
-                break;
-            }
-            case "Organism name": {
-                assemblyEntity.setOrganism(tagData);
-                break;
-            }
-            case "Taxid": {
-                assemblyEntity.setTaxid(Long.parseLong(tagData));
-                break;
-            }
-            case "GenBank assembly accession": {
-                assemblyEntity.setInsdcAccession(tagData);
-                break;
-            }
-            case "RefSeq assembly accession": {
-                assemblyEntity.setRefseq(tagData);
-                break;
-            }
-            case "RefSeq assembly and GenBank assemblies identical": {
-                assemblyEntity.setGenbankRefseqIdentical(tagData.equals("yes"));
-                break;
-            }
-        }
-    }
-
-    void parseChromosomeLine(String[] columns) {
-        ChromosomeEntity chromosomeEntity = new ChromosomeEntity();
-
-        chromosomeEntity.setGenbankSequenceName(columns[0]);
-        chromosomeEntity.setInsdcAccession(columns[4]);
-        if (columns[6] == null || columns[6].isEmpty() || columns[6].equals("na")) {
-            chromosomeEntity.setRefseq(null);
-        } else {
-            chromosomeEntity.setRefseq(columns[6]);
-        }
-
-        if (columns.length > 8) {
-            try {
-                Long seqLength = Long.parseLong(columns[8]);
-                chromosomeEntity.setSeqLength(seqLength);
-            } catch (NumberFormatException nfe) {
-
-            }
-        }
-
-        if (columns.length > 9 && !columns[9].equals("na")) {
-            chromosomeEntity.setUcscName(columns[9]);
-        }
-
-        if (assemblyEntity == null) {
-            assemblyEntity = new AssemblyEntity();
-        }
-        chromosomeEntity.setAssembly(this.assemblyEntity);
-        chromosomeEntity.setContigType(SequenceEntity.ContigType.CHROMOSOME);
-
-        List<ChromosomeEntity> chromosomes = this.assemblyEntity.getChromosomes();
-        if (chromosomes == null) {
-            chromosomes = new LinkedList<>();
-            assemblyEntity.setChromosomes(chromosomes);
-        }
-        chromosomes.add(chromosomeEntity);
-    }
-
-    void parseScaffoldLine(String[] columns) {
-        ChromosomeEntity scaffoldEntity = new ChromosomeEntity();
-
-        scaffoldEntity.setGenbankSequenceName(columns[0]);
-        scaffoldEntity.setInsdcAccession(columns[4]);
-        if (columns[6] == null || columns[6].isEmpty() || columns[6].equals("na")) {
-            scaffoldEntity.setRefseq(null);
-        } else {
-            scaffoldEntity.setRefseq(columns[6]);
-        }
-
-        if (columns.length > 8) {
-            try {
-                Long seqLength = Long.parseLong(columns[8]);
-                scaffoldEntity.setSeqLength(seqLength);
-            } catch (NumberFormatException nfe) {
-
-            }
-        }
-
-
-        if (columns.length >= 10) {
-            String ucscName = columns[9];
-            if (!ucscName.equals("na")) {
-                scaffoldEntity.setUcscName(ucscName);
-            }
-        }
-
-        if (assemblyEntity == null) {
-            assemblyEntity = new AssemblyEntity();
-        }
-        scaffoldEntity.setAssembly(this.assemblyEntity);
-        scaffoldEntity.setContigType(SequenceEntity.ContigType.SCAFFOLD);
-
-        List<ChromosomeEntity> scaffolds = this.assemblyEntity.getChromosomes();
-        if (scaffolds == null) {
-            scaffolds = new LinkedList<>();
-            assemblyEntity.setChromosomes(scaffolds);
-        }
-        scaffolds.add(scaffoldEntity);
+    AssemblySequenceEntity getAssemblySequenceEntity() throws IOException {
+        return sequenceReader.getAssemblySequencesEntity();
     }
 
     @Test
-    void addSequenceCollection() throws IOException {
-        parseFile();
-        parseReport();
+    @Order(1)
+    void addSequenceCollectionTest() throws IOException {
+        AssemblyEntity assemblyEntity = getAssemblyEntity();
+        AssemblySequenceEntity assemblySequenceEntity = getAssemblySequenceEntity();
         List<SeqColExtendedDataEntity> extendedDataEntities = extendedDataService.constructExtendedSeqColDataList(
-                assemblyEntity, assemblySequenceEntity, SeqColEntity.NamingConvention.GENBANK, GCA_ACCESSION
+                assemblyEntity, assemblySequenceEntity, SeqColEntity.NamingConvention.GENBANK
         );
         SeqColLevelOneEntity levelOneEntity = levelOneService.constructSeqColLevelOne(
                 extendedDataEntities, SeqColEntity.NamingConvention.GENBANK);
         Optional<String> resultDigest = seqColService.addFullSequenceCollection(levelOneEntity, extendedDataEntities);
         assertTrue(resultDigest.isPresent());
-        System.out.println("RESULT DIGEST: " + resultDigest);
     }
 
     @Test
-    @Disabled // Disabled on GitHub. Enable it when you have a seqcol already saved in your local db with the given digest
+    @Order(2)
     void getSeqColByDigestAndLevelTest() {
-        Optional<SeqColLevelOneEntity> levelOneEntity = (Optional<SeqColLevelOneEntity>) seqColService.getSeqColByDigestAndLevel("7eldYm-sjycc1MDEVSI5jmuNac4BO-eN", 1);
+        Optional<SeqColLevelOneEntity> levelOneEntity = (Optional<SeqColLevelOneEntity>) seqColService.getSeqColByDigestAndLevel(RESULT_DIGEST, 1);
         assertTrue(levelOneEntity.isPresent());
-        Optional<SeqColLevelTwoEntity> levelTwoEntity = (Optional<SeqColLevelTwoEntity>) seqColService.getSeqColByDigestAndLevel("7eldYm-sjycc1MDEVSI5jmuNac4BO-eN", 2);
+        Optional<SeqColLevelTwoEntity> levelTwoEntity = (Optional<SeqColLevelTwoEntity>) seqColService.getSeqColByDigestAndLevel(RESULT_DIGEST, 2);
         assertTrue(levelTwoEntity.isPresent());
-    }
-
-    @Test
-    void fetchAndInsertSeqColByAssemblyAccessionTesst() throws IOException {
-        try {
-            seqColService.fetchAndInsertSeqColByAssemblyAccession(GCA_ACCESSION, SeqColEntity.NamingConvention.GENBANK);
-        } catch (DuplicateSeqColException e) {
-            System.out.println(e.getMessage());
-        }
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("seqcol")
-//@Testcontainers
+@Testcontainers
 class SeqColServiceTest {
 
     private final String REPORT_FILE_PATH_1 = "src/test/resources/GCA_000146045.2_R64_assembly_report.txt";
@@ -68,7 +68,7 @@ class SeqColServiceTest {
     private SeqColService seqColService;
     private DigestCalculator digestCalculator;
 
-   /* @Container
+    @Container
     static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15.2");
 
     @DynamicPropertySource
@@ -77,7 +77,7 @@ class SeqColServiceTest {
         registry.add("spring.datasource.username", postgreSQLContainer::getUsername);
         registry.add("spring.datasource.password", postgreSQLContainer::getPassword);
         registry.add("spring.jpa.hibernate.ddl-auto", () -> "update");
-    }*/
+    }
 
     @BeforeEach
     void setUp() throws FileNotFoundException {

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -130,6 +130,7 @@ class SeqColServiceTest {
 
     @Test
     @Order(2)
+    @Disabled
     void getSeqColByDigestAndLevelTest() {
         Optional<SeqColLevelOneEntity> levelOneEntity = (Optional<SeqColLevelOneEntity>) seqColService.getSeqColByDigestAndLevel(RESULT_DIGEST, 1);
         assertTrue(levelOneEntity.isPresent());

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -13,10 +13,11 @@ import uk.ac.ebi.eva.evaseqcol.entities.ChromosomeEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
-import uk.ac.ebi.eva.evaseqcol.refget.DigestCalculator;
+import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
 import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
 
 import java.io.BufferedReader;
@@ -258,7 +259,7 @@ class SeqColServiceTest {
     }
 
     @Test
-    void addSequenceCollection() throws IOException {
+    String addSequenceCollection() throws IOException {
         parseFile();
         parseReport();
         List<SeqColExtendedDataEntity> extendedDataEntities = extendedDataService.constructExtendedSeqColDataList(
@@ -269,6 +270,17 @@ class SeqColServiceTest {
         Optional<String> resultDigest = seqColService.addFullSequenceCollection(levelOneEntity, extendedDataEntities);
         assertTrue(resultDigest.isPresent());
         System.out.println("RESULT DIGEST: " + resultDigest);
+        return resultDigest.get();
+    }
+
+    @Test
+    void getSeqColByDigestAndLevelTest() throws IOException {
+        String TEST_DIGEST = addSequenceCollection();
+        System.out.println("TEST DIGEST:" + TEST_DIGEST);
+        Optional<SeqColLevelOneEntity> levelOneEntity = (Optional<SeqColLevelOneEntity>) seqColService.getSeqColByDigestAndLevel(TEST_DIGEST, 1);
+        assertTrue(levelOneEntity.isPresent());
+        Optional<SeqColLevelTwoEntity> levelTwoEntity = (Optional<SeqColLevelTwoEntity>) seqColService.getSeqColByDigestAndLevel(TEST_DIGEST, 2);
+        assertTrue(levelTwoEntity.isPresent());
     }
 
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/utils/JSONExtDataTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/utils/JSONExtDataTest.java
@@ -1,0 +1,27 @@
+package uk.ac.ebi.eva.evaseqcol.utils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JSONExtDataTest {
+
+    private JSONExtData JSONExtDataObj;
+
+    @BeforeEach
+    void setUp() {
+        JSONExtDataObj = new JSONExtData();
+        List<String> arrElements = Arrays.asList("A", "B", "C");
+        JSONExtDataObj.setObject(arrElements);
+
+    }
+
+    @Test
+    void testToString() {
+        assertEquals("[\"A\",\"B\",\"C\"]", JSONExtDataObj.toString());
+    }
+}


### PR DESCRIPTION
 Full ingest of seqCol level1 and level2 objects

- Insert level1 seqCol in the db
- Insert extended seqCol attributes data in the db
- Retrieve level1 seqCol (with 1 db lookup)
- Retrieve level2 seqCol (with 2 db lookups)

**Note:** some of the tests are activated with the profile 'seqcol', so it requries local run (local db).