### PR TITLE
fixed the digest calculation algorithm

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSource.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSource.java
@@ -11,9 +11,8 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
-import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
-import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
-import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
+import uk.ac.ebi.eva.evaseqcol.refget.MD5ChecksumCalculator;
+import uk.ac.ebi.eva.evaseqcol.refget.SHA512ChecksumCalculator;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
 
 import java.io.IOException;
@@ -29,8 +28,8 @@ public class NCBISeqColDataSource implements SeqColDataSource{
     private final NCBIAssemblyDataSource assemblyDataSource;
     private final NCBIAssemblySequenceDataSource assemblySequenceDataSource;
     private DigestCalculator digestCalculator = new DigestCalculator();
-    private ChecksumCalculator sha512Calculator = new SHA512Calculator();
-    private ChecksumCalculator md5Caclculator = new MD5Calculator();
+    private SHA512ChecksumCalculator sha512ChecksumCalculator = new SHA512ChecksumCalculator();
+    private MD5ChecksumCalculator md5Caclculator = new MD5ChecksumCalculator();
 
     @Autowired
     public NCBISeqColDataSource(NCBIAssemblyDataSource assemblyDataSource,

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/digests/DigestCalculator.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/digests/DigestCalculator.java
@@ -2,14 +2,14 @@ package uk.ac.ebi.eva.evaseqcol.digests;
 
 import org.erdtman.jcs.JsonCanonicalizer;
 
-import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
+import uk.ac.ebi.eva.evaseqcol.refget.SHA512ChecksumCalculator;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Base64;
 
 public class DigestCalculator {
-    private SHA512Calculator sha512Calculator = new SHA512Calculator();
+    private SHA512ChecksumCalculator sha512ChecksumCalculator = new SHA512ChecksumCalculator();
     private JsonCanonicalizer jc;
 
     /**
@@ -17,7 +17,7 @@ public class DigestCalculator {
      * */
     public String getSha512Digest(String input) throws IOException {
         jc = new JsonCanonicalizer(input);
-        byte[] hashed =  sha512Calculator.SHA512Hash(jc.getEncodedString());
+        byte[] hashed =  sha512ChecksumCalculator.SHA512Hash(jc.getEncodedString());
         byte[] truncatedSequence = Arrays.copyOfRange(hashed, 0, 24);
         String text = Base64.getUrlEncoder().encodeToString(truncatedSequence);
         return text;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/dus/NCBIAssemblySequenceReader.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/dus/NCBIAssemblySequenceReader.java
@@ -2,9 +2,8 @@ package uk.ac.ebi.eva.evaseqcol.dus;
 
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColSequenceEntity;
-import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
-import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
-import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
+import uk.ac.ebi.eva.evaseqcol.refget.MD5ChecksumCalculator;
+import uk.ac.ebi.eva.evaseqcol.refget.SHA512ChecksumCalculator;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -21,8 +20,8 @@ public class NCBIAssemblySequenceReader extends AssemblySequenceReader {
         if (reader == null){
             throw new NullPointerException("Cannot use AssemblySequenceReader without having a valid InputStreamReader.");
         }
-        ChecksumCalculator md5Calculator = new MD5Calculator();
-        ChecksumCalculator sha512Calculator = new SHA512Calculator();
+        MD5ChecksumCalculator md5ChecksumCalculator = new MD5ChecksumCalculator();
+        SHA512ChecksumCalculator sha512ChecksumCalculator = new SHA512ChecksumCalculator();
         if (assemblySequenceEntity == null){
             assemblySequenceEntity = new AssemblySequenceEntity();
         }
@@ -42,8 +41,8 @@ public class NCBIAssemblySequenceReader extends AssemblySequenceReader {
                     sequenceValue.append(line);
                     line = reader.readLine();
                 }
-                String md5checksum = md5Calculator.calculateChecksum(sequenceValue.toString());
-                String sha512Checksum = sha512Calculator.calculateChecksum(sequenceValue.toString());
+                String md5checksum = md5ChecksumCalculator.calculateChecksum(sequenceValue.toString());
+                String sha512Checksum = sha512ChecksumCalculator.calculateRefgetChecksum(sequenceValue.toString());
                 sequence.setSequenceMD5(md5checksum);
                 sequence.setSequence(sha512Checksum);
                 sequences.add(sequence);

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColExtendedDataEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColExtendedDataEntity.java
@@ -6,7 +6,7 @@ import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
-import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
+import uk.ac.ebi.eva.evaseqcol.refget.SHA512ChecksumCalculator;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 
 import javax.persistence.Basic;
@@ -75,10 +75,10 @@ public class SeqColExtendedDataEntity {
                     break;
             }
         }
-        SHA512Calculator sha512Calculator = new SHA512Calculator();
+        SHA512ChecksumCalculator sha512ChecksumCalculator = new SHA512ChecksumCalculator();
         seqColNamesArray.setObject(namesList);
         seqColNamesObject.setExtendedSeqColData(seqColNamesArray);
-        seqColNamesObject.setDigest(sha512Calculator.calculateChecksum(seqColNamesArray.toString()));
+        seqColNamesObject.setDigest(sha512ChecksumCalculator.calculateChecksum(seqColNamesArray.toString()));
         return seqColNamesObject;
     }
 
@@ -93,10 +93,10 @@ public class SeqColExtendedDataEntity {
         for (SequenceEntity chromosome: assemblyEntity.getChromosomes()) {
             lengthsList.add(chromosome.getSeqLength().toString());
         }
-        SHA512Calculator sha512Calculator = new SHA512Calculator();
+        SHA512ChecksumCalculator sha512ChecksumCalculator = new SHA512ChecksumCalculator();
         seqColLengthsArray.setObject(lengthsList);
         seqColLengthsObject.setExtendedSeqColData(seqColLengthsArray);
-        seqColLengthsObject.setDigest(sha512Calculator.calculateChecksum(seqColLengthsArray.toString()));
+        seqColLengthsObject.setDigest(sha512ChecksumCalculator.calculateChecksum(seqColLengthsArray.toString()));
         return seqColLengthsObject;
     }
 
@@ -111,10 +111,10 @@ public class SeqColExtendedDataEntity {
         for (SeqColSequenceEntity sequence: assemblySequenceEntity.getSequences()) {
             sequencesList.add(sequence.getSequence());
         }
-        SHA512Calculator sha512Calculator = new SHA512Calculator();
+        SHA512ChecksumCalculator sha512ChecksumCalculator = new SHA512ChecksumCalculator();
         seqColSequencesArray.setObject(sequencesList);
         seqColSequencesObject.setExtendedSeqColData(seqColSequencesArray);
-        seqColSequencesObject.setDigest(sha512Calculator.calculateChecksum(seqColSequencesArray.toString()));
+        seqColSequencesObject.setDigest(sha512ChecksumCalculator.calculateChecksum(seqColSequencesArray.toString()));
         return seqColSequencesObject;
     }
 
@@ -129,10 +129,10 @@ public class SeqColExtendedDataEntity {
         for (SeqColSequenceEntity sequence: assemblySequenceEntity.getSequences()) {
             sequencesList.add(sequence.getSequenceMD5());
         }
-        SHA512Calculator sha512Calculator = new SHA512Calculator();
+        SHA512ChecksumCalculator sha512ChecksumCalculator = new SHA512ChecksumCalculator();
         seqColSequencesArray.setObject(sequencesList);
         seqColSequencesObject.setExtendedSeqColData(seqColSequencesArray);
-        seqColSequencesObject.setDigest(sha512Calculator.calculateChecksum(seqColSequencesArray.toString()));
+        seqColSequencesObject.setDigest(sha512ChecksumCalculator.calculateChecksum(seqColSequencesArray.toString()));
         return seqColSequencesObject;
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/refget/ChecksumCalculator.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/refget/ChecksumCalculator.java
@@ -1,6 +1,0 @@
-package uk.ac.ebi.eva.evaseqcol.refget;
-
-public abstract class ChecksumCalculator {
-
-    public abstract String calculateChecksum(String sequence);
-}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/refget/MD5ChecksumCalculator.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/refget/MD5ChecksumCalculator.java
@@ -4,9 +4,8 @@ import javax.xml.bind.DatatypeConverter;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-public class MD5Calculator extends ChecksumCalculator{
+public class MD5ChecksumCalculator {
 
-    @Override
     /**
      * Return the MD5 checksum of the given sequence following the Refget API Specification v1.0.1
      * @param sequence the sequence of which we want to calculate the md5 checksum for

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/refget/SHA512ChecksumCalculator.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/refget/SHA512ChecksumCalculator.java
@@ -5,13 +5,14 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
 
-public class SHA512Calculator extends ChecksumCalculator{
+public class SHA512ChecksumCalculator {
 
-    @Override
     /**
-     * Calculate the refget checksum (ga4gh) of the given sequence
+     * Calculate the GA4GH-SHA512 Refget checksum of the given sequence.
+     * Adds the 'SQ.' at the beginning of the resulting digest.
+     * Used to calculate the 'sequence's digest.
      * */
-    public String calculateChecksum(String sequence) {
+    public String calculateRefgetChecksum(String sequence) {
         String sequence1 = sequence.replaceAll("[\\W]|_", ""); // Remove non-alphanumeric characters
         byte[] digest = SHA512Hash(sequence1.toUpperCase());
 
@@ -19,6 +20,20 @@ public class SHA512Calculator extends ChecksumCalculator{
         byte[] truncatedSequence = Arrays.copyOfRange(digest, 0, 24);
         String encodedBase64Sequence = Base64.getUrlEncoder().encodeToString(truncatedSequence);
         return "SQ." + encodedBase64Sequence;
+    }
+
+    /**
+     * Calculate the GA4GH-SHA512 checksum of the given sequence.
+     * Used to calculate the digest of attributes other than the 'sequence'.
+     * */
+    public String calculateChecksum(String input) {
+        String sequence1 = input.replaceAll("[\\W]|_", ""); // Remove non-alphanumeric characters
+        byte[] digest = SHA512Hash(sequence1.toUpperCase());
+
+        // Encode the first 24 bytes with Base64
+        byte[] truncatedSequence = Arrays.copyOfRange(digest, 0, 24);
+        String encodedBase64Sequence = Base64.getUrlEncoder().encodeToString(truncatedSequence);
+        return encodedBase64Sequence;
     }
 
     public byte[] SHA512Hash(String text) {

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/refget/SHA512ChecksumCalculator.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/refget/SHA512ChecksumCalculator.java
@@ -13,13 +13,7 @@ public class SHA512ChecksumCalculator {
      * Used to calculate the 'sequence's digest.
      * */
     public String calculateRefgetChecksum(String sequence) {
-        String sequence1 = sequence.replaceAll("[\\W]|_", ""); // Remove non-alphanumeric characters
-        byte[] digest = SHA512Hash(sequence1.toUpperCase());
-
-        // Encode the first 24 bytes with Base64
-        byte[] truncatedSequence = Arrays.copyOfRange(digest, 0, 24);
-        String encodedBase64Sequence = Base64.getUrlEncoder().encodeToString(truncatedSequence);
-        return "SQ." + encodedBase64Sequence;
+        return "SQ." + calculateChecksum(sequence);
     }
 
     /**

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataService.java
@@ -10,9 +10,8 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.exception.ExtendedDataNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
-import uk.ac.ebi.eva.evaseqcol.refget.ChecksumCalculator;
-import uk.ac.ebi.eva.evaseqcol.refget.MD5Calculator;
-import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
+import uk.ac.ebi.eva.evaseqcol.refget.MD5ChecksumCalculator;
+import uk.ac.ebi.eva.evaseqcol.refget.SHA512ChecksumCalculator;
 import uk.ac.ebi.eva.evaseqcol.repo.SeqColExtendedDataRepository;
 
 import java.io.IOException;
@@ -26,8 +25,8 @@ public class SeqColExtendedDataService {
     @Autowired
     private SeqColExtendedDataRepository repository;
 
-    private ChecksumCalculator sha512Calculator = new SHA512Calculator();
-    private ChecksumCalculator md5Calculator = new MD5Calculator();
+    private SHA512ChecksumCalculator sha512ChecksumCalculator = new SHA512ChecksumCalculator();
+    private MD5ChecksumCalculator md5ChecksumCalculator = new MD5ChecksumCalculator();
 
     /**
      * Add a seqCol's attribute; names, lengths or sequences, to the database*/

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -8,7 +8,7 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
-import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
+import uk.ac.ebi.eva.evaseqcol.refget.SHA512ChecksumCalculator;
 import uk.ac.ebi.eva.evaseqcol.repo.SeqColLevelOneRepository;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
@@ -85,7 +85,7 @@ public class SeqColLevelOneService {
      * Construct a Level 1 seqCol out of a Level 2 seqCol*/
     public SeqColLevelOneEntity constructSeqColLevelOne(
             SeqColLevelTwoEntity levelTwoEntity, SeqColEntity.NamingConvention convention) throws IOException {
-        SHA512Calculator sha512Calculator = new SHA512Calculator();
+        SHA512ChecksumCalculator sha512Calculator = new SHA512ChecksumCalculator();
         JSONExtData sequencesExtData = new JSONExtData(levelTwoEntity.getSequences());
         JSONExtData lengthsExtData = new JSONExtData(levelTwoEntity.getLengths());
         JSONExtData namesExtData = new JSONExtData(levelTwoEntity.getNames());

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/refget/MD5ChecksumCalculatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/refget/MD5ChecksumCalculatorTest.java
@@ -19,14 +19,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class MD5CalculatorTest {
+class MD5ChecksumCalculatorTest {
     private final String FIRST_SEQ_REFSEQ = "NW_001589959.2";
     private final Integer FIRST_SEQ_SIZE = 2692213;
     private final String FIRST_SEQ_MD5 = "87faa0a4adb9b68d291900d666800c40"; // The md5 hash of the first sequence in the fasta file
     private BufferedReader reader;
     private InputStreamReader streamReader;
     private InputStream stream;
-    private ChecksumCalculator md5Calculator;
+    private MD5ChecksumCalculator md5ChecksumCalculator;
 
     @BeforeEach
     void setUp() throws FileNotFoundException {
@@ -34,7 +34,7 @@ class MD5CalculatorTest {
                 new File("src/test/resources/GCF_000001765.3_genome_sequence.fna"));
         streamReader = new InputStreamReader(stream);
         reader = new BufferedReader(streamReader);
-        md5Calculator = new MD5Calculator();
+        md5ChecksumCalculator = new MD5ChecksumCalculator();
 
     }
 
@@ -77,7 +77,7 @@ class MD5CalculatorTest {
     void calculateChecksum() throws IOException {
         Optional<String> testSequence = getSequenceByRefseqFromFastaFile(FIRST_SEQ_REFSEQ);
         assertTrue(testSequence.isPresent());
-        assertEquals(md5Calculator.calculateChecksum(testSequence.get()), FIRST_SEQ_MD5);
+        assertEquals(md5ChecksumCalculator.calculateChecksum(testSequence.get()), FIRST_SEQ_MD5);
     }
 
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/refget/SHA512ChecksumCalculatorTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/refget/SHA512ChecksumCalculatorTest.java
@@ -2,7 +2,6 @@ package uk.ac.ebi.eva.evaseqcol.refget;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
@@ -20,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class SHA512CalculatorTest {
+class SHA512ChecksumCalculatorTest {
 
     private final String SEQ_REFSEQ = "BK006935.2";
     private final Integer SEQ_SIZE = 230218;
@@ -28,7 +27,7 @@ class SHA512CalculatorTest {
     private BufferedReader reader;
     private InputStreamReader streamReader;
     private InputStream stream;
-    private ChecksumCalculator sha512Calculator;
+    private SHA512ChecksumCalculator sha512ChecksumCalculator;
 
     @BeforeEach
     void setUp() throws FileNotFoundException {
@@ -36,7 +35,7 @@ class SHA512CalculatorTest {
                 new File("src/test/resources/GCA_000146045.2_genome_sequence.fna"));
         streamReader = new InputStreamReader(stream);
         reader = new BufferedReader(streamReader);
-        sha512Calculator = new SHA512Calculator();
+        sha512ChecksumCalculator = new SHA512ChecksumCalculator();
 
     }
 
@@ -79,7 +78,7 @@ class SHA512CalculatorTest {
     void calculateChecksum() throws IOException {
         Optional<String> testSequence = getSequenceByRefseqFromFastaFile(SEQ_REFSEQ);
         assertTrue(testSequence.isPresent());
-        assertEquals(sha512Calculator.calculateChecksum("ACGT"), "SQ.aKF498dAxcJAqme6QYQ7EZ07-fiw8Kw2");
-        assertEquals(sha512Calculator.calculateChecksum(testSequence.get()), SEQ_MD5);
+        assertEquals(sha512ChecksumCalculator.calculateRefgetChecksum("ACGT"), "SQ.aKF498dAxcJAqme6QYQ7EZ07-fiw8Kw2");
+        assertEquals(sha512ChecksumCalculator.calculateRefgetChecksum(testSequence.get()), SEQ_MD5);
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
@@ -20,7 +20,7 @@ import uk.ac.ebi.eva.evaseqcol.entities.AssemblyEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.AssemblySequenceEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
-import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
+import uk.ac.ebi.eva.evaseqcol.refget.SHA512ChecksumCalculator;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -62,7 +62,7 @@ class SeqColExtendedDataServiceTest {
     @Autowired
     private SeqColExtendedDataService extendedDataService;
 
-    private SHA512Calculator sha512Calculator = new SHA512Calculator();
+    private SHA512ChecksumCalculator sha512ChecksumCalculator = new SHA512ChecksumCalculator();
 
     @Container
     static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>("postgres:15.2");


### PR DESCRIPTION
Updated the digest calculation algorithm as follows:

- Use of Refget ga4gh-sha512 algorithm to calculate each sequence's digest (adds the 'SQ.' at the beginning of the digest)
- Use of ga4gh-512 algorithm to calculate the arrays' (attributes level 2) digest.