### PR TITLE
Seqcol comparison api generic version - using low level reflection libraries 

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/authentication/SecurityConfiguration.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/authentication/SecurityConfiguration.java
@@ -16,6 +16,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
             .antMatchers("/collection/**").permitAll()
             .antMatchers("/collection/admin/**").permitAll()
+            .antMatchers("/comparison/**").permitAll()
             .and().sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
     }
 

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
@@ -1,0 +1,40 @@
+package uk.ac.ebi.eva.evaseqcol.controller.seqcol;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColComparisonResultEntity;
+import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
+import uk.ac.ebi.eva.evaseqcol.service.SeqColService;
+
+@RestController
+@RequestMapping("/comparison")
+public class SeqColComparisonController {
+
+    private SeqColService seqColService;
+
+    @Autowired
+    public SeqColComparisonController(SeqColService seqColService) {
+        this.seqColService = seqColService;
+    }
+
+    @GetMapping("/{digest1}/{digest2}")
+    public ResponseEntity<?> compareSequenceCollections(
+            @PathVariable String digest1, @PathVariable String digest2) {
+        try {
+            SeqColComparisonResultEntity comparisonResult = seqColService.compareSeqCols1(digest1, digest2);
+            return new ResponseEntity<>(comparisonResult, HttpStatus.OK);
+        } catch (NoSuchFieldException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (SeqColNotFoundException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
@@ -5,12 +5,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColComparisonResultEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.service.SeqColService;
+
+import java.io.IOException;
 
 @RestController
 @RequestMapping("/comparison")
@@ -27,13 +33,29 @@ public class SeqColComparisonController {
     public ResponseEntity<?> compareSequenceCollections(
             @PathVariable String digest1, @PathVariable String digest2) {
         try {
-            SeqColComparisonResultEntity comparisonResult = seqColService.compareSeqCols1(digest1, digest2);
+            SeqColComparisonResultEntity comparisonResult = seqColService.compareSeqCols(digest1, digest2);
             return new ResponseEntity<>(comparisonResult, HttpStatus.OK);
         } catch (NoSuchFieldException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (SeqColNotFoundException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
         } catch (Exception e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PostMapping("/{digest1}")
+    public ResponseEntity<?> compareSequenceCollections(
+            @PathVariable String digest1, @RequestBody SeqColLevelTwoEntity seqColLevelTwo
+            ) {
+        System.out.println("seqColL2: " + seqColLevelTwo.toString());
+        try {
+            SeqColComparisonResultEntity comparisonResult = seqColService.compareSeqCols(digest1, seqColLevelTwo, SeqColEntity.NamingConvention.GENBANK);
+            return new ResponseEntity<>(comparisonResult, HttpStatus.OK);
+        } catch (SeqColNotFoundException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            e.printStackTrace();
             return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
@@ -30,6 +30,10 @@ public class SeqColComparisonController {
     }
 
     @GetMapping("/{digest1}/{digest2}")
+    /**
+     * Compare two seqCol objects given their level 0 digests.
+     * @see "https://github.com/ga4gh/seqcol-spec/blob/master/docs/decision_record.md#2022-06-15---structure-for-the-return-value-of-the-comparison-api-endpoint"
+     * for more details.*/
     public ResponseEntity<?> compareSequenceCollections(
             @PathVariable String digest1, @PathVariable String digest2) {
         try {
@@ -44,6 +48,10 @@ public class SeqColComparisonController {
         }
     }
 
+    /**
+     * Compare two seqCol objects given the level 0 digest of the first and the level 2 object of the second.
+     * @see "https://github.com/ga4gh/seqcol-spec/blob/master/docs/decision_record.md#2022-06-15---structure-for-the-return-value-of-the-comparison-api-endpoint"
+     * for more details.*/
     @PostMapping("/{digest1}")
     public ResponseEntity<?> compareSequenceCollections(
             @PathVariable String digest1, @RequestBody SeqColLevelTwoEntity seqColLevelTwo

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
@@ -1,0 +1,53 @@
+package uk.ac.ebi.eva.evaseqcol.entities;
+
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class SeqColComparisonResultEntity {
+    /**
+     * The "digests" attribute contains two sub-attributes:
+     *  "a" and "b", which represents the digests of seqCol a and
+     *  seqCol b respectively*/
+    private Map<String, String> digests;
+
+    /**
+     * The "arrays" attribute contains three sub-attributes:
+     *  "a-only", "b-only", "a-and-b"*/
+    private Map<String, List<String>> arrays;
+
+    /**
+     * The "elements" attribute contains three sub-attributes:
+     *  "total", "a-and-b", "a-and-b-same-order"*/
+    private Map<String, Map<String, Object>> elements; // The object can be either Integer or Boolean
+
+
+    public SeqColComparisonResultEntity() {
+        this.digests = new HashMap<>();
+        this.arrays = new HashMap<>();
+        this.elements = new HashMap<>();
+        elements.put("total", new HashMap<>());
+        elements.put("a-and-b", new HashMap<>());
+        elements.put("a-and-b-same-order", new HashMap<>());
+
+    }
+
+    /**
+     * @param seqColId The seqCol identifier: "a" or "b"
+     * @param digest The digest of the given seqCol*/
+    public void putIntoDigests(String seqColId, String digest) {
+        digests.put(seqColId, digest);
+    }
+
+    public void putIntoArrays(String key, List<String> value) {
+        arrays.put(key, value);
+    }
+
+    public void putIntoElements(String elementName,String key, Object value) {
+        Map<String, Object> elementsMap = elements.get(elementName);
+        elementsMap.put(key, value);
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -7,10 +7,14 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
+import uk.ac.ebi.eva.evaseqcol.refget.SHA512Calculator;
 import uk.ac.ebi.eva.evaseqcol.repo.SeqColLevelOneRepository;
+import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -77,5 +81,43 @@ public class SeqColLevelOneService {
         return levelOneEntity;
     }
 
+    /**
+     * Construct a Level 1 seqCol out of a Level 2 seqCol*/
+    public SeqColLevelOneEntity constructSeqColLevelOne(
+            SeqColLevelTwoEntity levelTwoEntity, SeqColEntity.NamingConvention convention) throws IOException {
+        SHA512Calculator sha512Calculator = new SHA512Calculator();
+        JSONExtData sequencesExtData = new JSONExtData(levelTwoEntity.getSequences());
+        JSONExtData lengthsExtData = new JSONExtData(levelTwoEntity.getLengths());
+        JSONExtData namesExtData = new JSONExtData(levelTwoEntity.getNames());
+        JSONExtData md5SequencesExtData = new JSONExtData(levelTwoEntity.getMd5Sequences());
 
+        // Sequences
+        SeqColExtendedDataEntity sequencesExtEntity = new SeqColExtendedDataEntity();
+        sequencesExtEntity.setAttributeType(SeqColExtendedDataEntity.AttributeType.sequences);
+        sequencesExtEntity.setExtendedSeqColData(sequencesExtData);
+        sequencesExtEntity.setDigest(sha512Calculator.calculateChecksum(sequencesExtData.toString()));
+        // Md5Sequences
+        SeqColExtendedDataEntity md5SequencesExtEntity = new SeqColExtendedDataEntity();
+        md5SequencesExtEntity.setAttributeType(SeqColExtendedDataEntity.AttributeType.sequencesMD5);
+        md5SequencesExtEntity.setExtendedSeqColData(md5SequencesExtData);
+        md5SequencesExtEntity.setDigest(sha512Calculator.calculateChecksum(md5SequencesExtData.toString()));
+        // Lengths
+        SeqColExtendedDataEntity lengthsExtEntity = new SeqColExtendedDataEntity();
+        lengthsExtEntity.setAttributeType(SeqColExtendedDataEntity.AttributeType.lengths);
+        lengthsExtEntity.setExtendedSeqColData(lengthsExtData);
+        lengthsExtEntity.setDigest(sha512Calculator.calculateChecksum(lengthsExtData.toString()));
+        // Names
+        SeqColExtendedDataEntity namesExtEntity = new SeqColExtendedDataEntity();
+        namesExtEntity.setAttributeType(SeqColExtendedDataEntity.AttributeType.names);
+        namesExtEntity.setExtendedSeqColData(namesExtData);
+        namesExtEntity.setDigest(sha512Calculator.calculateChecksum(namesExtData.toString()));
+
+        List<SeqColExtendedDataEntity> extendedDataEntities = Arrays.asList(
+                sequencesExtEntity,
+                md5SequencesExtEntity,
+                lengthsExtEntity,
+                namesExtEntity
+        );
+        return constructSeqColLevelOne(extendedDataEntities, convention);
+    }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -98,7 +98,7 @@ public class SeqColLevelOneService {
         sequencesExtEntity.setDigest(sha512Calculator.calculateChecksum(sequencesExtData.toString()));
         // Md5Sequences
         SeqColExtendedDataEntity md5SequencesExtEntity = new SeqColExtendedDataEntity();
-        md5SequencesExtEntity.setAttributeType(SeqColExtendedDataEntity.AttributeType.sequencesMD5);
+        md5SequencesExtEntity.setAttributeType(SeqColExtendedDataEntity.AttributeType.md5DigestsOfSequences);
         md5SequencesExtEntity.setExtendedSeqColData(md5SequencesExtData);
         md5SequencesExtEntity.setDigest(sha512Calculator.calculateChecksum(md5SequencesExtData.toString()));
         // Lengths

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
@@ -103,7 +103,7 @@ public class SeqColLevelTwoService {
                 case sequences:
                     levelTwoEntity.setSequences(extendedData.getExtendedSeqColData().getObject());
                     break;
-                case sequencesMD5:
+                case md5DigestsOfSequences:
                     levelTwoEntity.setMd5Sequences(extendedData.getExtendedSeqColData().getObject());
                     break;
             }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
@@ -89,4 +89,25 @@ public class SeqColLevelTwoService {
         );
     }
 
+    public SeqColLevelTwoEntity constructSeqColL2(String level0Digest, List<SeqColExtendedDataEntity> extendedDataEntities) {
+        SeqColLevelTwoEntity levelTwoEntity = new SeqColLevelTwoEntity();
+        levelTwoEntity.setDigest(level0Digest);
+        for (SeqColExtendedDataEntity extendedData: extendedDataEntities) {
+            switch (extendedData.getAttributeType()) {
+                case lengths:
+                    levelTwoEntity.setLengths(extendedData.getExtendedSeqColData().getObject());
+                    break;
+                case names:
+                    levelTwoEntity.setNames(extendedData.getExtendedSeqColData().getObject());
+                    break;
+                case sequences:
+                    levelTwoEntity.setSequences(extendedData.getExtendedSeqColData().getObject());
+                    break;
+                case sequencesMD5:
+                    levelTwoEntity.setMd5Sequences(extendedData.getExtendedSeqColData().getObject());
+                    break;
+            }
+        }
+        return levelTwoEntity;
+    }
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -48,7 +48,7 @@ class SeqColServiceTest {
     private final String SEQUENCES_FILE_PATH_1 = "src/test/resources/GCA_000146045.2_genome_sequence.fna";
     private static final String GCA_ACCESSION = "GCA_000146045.2";
 
-    private final String TEST_DIGEST = "7eldYm-sjycc1MDEVSI5jmuNac4BO-eN";
+    private final String TEST_DIGEST = "81lThZbQdNVMKYlcQCKs-GFTKRr__EdX";
     private static InputStreamReader sequencesStreamReader;
     private static InputStream sequencesStream;
 

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -132,8 +132,8 @@ class SeqColServiceTest {
     //@Order(2)
     @Disabled
     void getSeqColByDigestAndLevelTest() {
-       /* Optional<SeqColLevelOneEntity> levelOneEntity = (Optional<SeqColLevelOneEntity>) seqColService.getSeqColByDigestAndLevel(RESULT_DIGEST, 1);
-        assertTrue(levelOneEntity.isPresent());*/
+        Optional<SeqColLevelOneEntity> levelOneEntity = (Optional<SeqColLevelOneEntity>) seqColService.getSeqColByDigestAndLevel(TEST_DIGEST, 1);
+        assertTrue(levelOneEntity.isPresent());
         Optional<SeqColLevelTwoEntity> levelTwoEntity = (Optional<SeqColLevelTwoEntity>) seqColService.getSeqColByDigestAndLevel(TEST_DIGEST, 2);
         assertTrue(levelTwoEntity.isPresent());
     }


### PR DESCRIPTION
In this PR, we'll try to make the comparison API more generic and flexible regarding the sequence collections inputs.
Not all seqCol objects will have the same set of attributes, however some attributes are required.