### PR TITLE
fetch and insert all possible seqCol objects from one assembly read

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
@@ -8,13 +8,12 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
+import uk.ac.ebi.eva.evaseqcol.exception.AssemblyNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColException;
 import uk.ac.ebi.eva.evaseqcol.service.SeqColService;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 @RequestMapping("/collection/admin")
 @RestController
@@ -31,7 +30,7 @@ public class AdminController {
      * Fetch and insert all possible seqCol objects given the assembly accession
      * NOTE: All possible means with all naming conventions that exist in the fetched assembly report*/
     @PutMapping(value = "/seqcols/{asmAccession}")
-    public ResponseEntity<?> fetchAndInsertSeqColByAssemblyAccessionAndNamingConvention(
+    public ResponseEntity<?> fetchAndInsertSeqColByAssemblyAccession(
             @PathVariable String asmAccession) {
         try {
             List<String> level0Digests = seqColService.fetchAndInsertAllSeqColByAssemblyAccession(asmAccession);
@@ -45,6 +44,8 @@ public class AdminController {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (DuplicateSeqColException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.OK);
+        } catch (AssemblyNotFoundException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
         }
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
@@ -13,6 +13,7 @@ import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColException;
 import uk.ac.ebi.eva.evaseqcol.service.SeqColService;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 @RequestMapping("/collection/admin")
@@ -27,16 +28,15 @@ public class AdminController {
     }
 
     /**
-     * Naming convention should be either ENA, GENBANK or UCSC */
-    @PutMapping(value = "/seqcols/{asmAccession}/{namingConvention}")
+     * Fetch and insert all possible seqCol objects given the assembly accession
+     * NOTE: All possible means with all naming conventions that exist in the fetched assembly report*/
+    @PutMapping(value = "/seqcols/{asmAccession}")
     public ResponseEntity<?> fetchAndInsertSeqColByAssemblyAccessionAndNamingConvention(
-            @PathVariable String asmAccession, @PathVariable String namingConvention) {
-        // TODO: REMOVE THE NAMING CONVENTION PATH VARIABLE AND MAKE IT GENERIC
+            @PathVariable String asmAccession) {
         try {
-            Optional<String> level0Digest = seqColService.fetchAndInsertSeqColByAssemblyAccession(
-                    asmAccession, SeqColEntity.NamingConvention.valueOf(namingConvention));
+            List<String> level0Digests = seqColService.fetchAndInsertAllSeqColByAssemblyAccession(asmAccession);
             return new ResponseEntity<>(
-                    "Successfully inserted seqCol for assemblyAccession " + asmAccession + "\nDigest=" + level0Digest.get()
+                    "Successfully inserted seqCol object(s) for assembly accession " + asmAccession + "\nSeqCol digests=" + level0Digests
                     , HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/SeqColDataSource.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/datasource/SeqColDataSource.java
@@ -1,14 +1,16 @@
 package uk.ac.ebi.eva.evaseqcol.datasource;
 
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 
 public interface SeqColDataSource {
-    Optional<SeqColLevelOneEntity> getSeqColL1ByAssemblyAccession(
-            String accesison, SeqColEntity.NamingConvention namingConvention) throws IOException;
+    Optional<Map<String, List<SeqColExtendedDataEntity>>> getAllPossibleSeqColExtendedData(String accession) throws IOException;
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataService.java
@@ -10,8 +10,6 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.exception.ExtendedDataNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
-import uk.ac.ebi.eva.evaseqcol.refget.MD5ChecksumCalculator;
-import uk.ac.ebi.eva.evaseqcol.refget.SHA512ChecksumCalculator;
 import uk.ac.ebi.eva.evaseqcol.repo.SeqColExtendedDataRepository;
 
 import java.io.IOException;
@@ -24,9 +22,6 @@ public class SeqColExtendedDataService {
 
     @Autowired
     private SeqColExtendedDataRepository repository;
-
-    private SHA512ChecksumCalculator sha512ChecksumCalculator = new SHA512ChecksumCalculator();
-    private MD5ChecksumCalculator md5ChecksumCalculator = new MD5ChecksumCalculator();
 
     /**
      * Add a seqCol's attribute; names, lengths or sequences, to the database*/
@@ -82,7 +77,7 @@ public class SeqColExtendedDataService {
         return Arrays.asList(
                 SeqColExtendedDataEntity.constructSeqColSequencesObject(assemblySequenceEntity),
                 SeqColExtendedDataEntity.constructSeqColSequencesMd5Object(assemblySequenceEntity),
-                SeqColExtendedDataEntity.constructSeqColNamesObject(assemblyEntity, convention),
+                SeqColExtendedDataEntity.constructSeqColNamesObjectByNamingConvention(assemblyEntity, convention),
                 SeqColExtendedDataEntity.constructSeqColLengthsObject(assemblyEntity)
         );
     }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -55,7 +55,7 @@ public class SeqColLevelOneService {
      * Construct a seqCol level 1 entity out of three seqCol level 2 entities that
      * hold names, lengths and sequences objects*/
     public SeqColLevelOneEntity constructSeqColLevelOne(List<SeqColExtendedDataEntity> extendedDataEntities,
-                                                 SeqColEntity.NamingConvention convention) throws IOException {
+                                                        SeqColEntity.NamingConvention convention) throws IOException {
         SeqColLevelOneEntity levelOneEntity = new SeqColLevelOneEntity();
         JSONLevelOne jsonLevelOne = new JSONLevelOne();
         for (SeqColExtendedDataEntity dataEntity: extendedDataEntities) {

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSourceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/datasource/NCBISeqColDataSourceTest.java
@@ -5,10 +5,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import uk.ac.ebi.eva.evaseqcol.entities.AssemblyEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -18,16 +22,17 @@ import static org.junit.jupiter.api.Assertions.*;
 class NCBISeqColDataSourceTest {
 
     private final String GCA_ACCESSION = "GCA_000146045.2";
-    private final SeqColEntity.NamingConvention NAMING_CONVENTION = SeqColEntity.NamingConvention.GENBANK;
 
     @Autowired
     private NCBISeqColDataSource ncbiSeqColDataSource;
 
     @Test
     void getSeqColL1ByAssemblyAccession() throws IOException {
-        Optional<SeqColLevelOneEntity> levelOneEntity = ncbiSeqColDataSource.getSeqColL1ByAssemblyAccession(
-                GCA_ACCESSION, NAMING_CONVENTION);
-        assertTrue(levelOneEntity.isPresent());
-        assertFalse(levelOneEntity.get().getSeqColLevel1Object().getSequences().isEmpty());
+        Optional<Map<String, List<SeqColExtendedDataEntity>>> fetchSeqColData = ncbiSeqColDataSource.getAllPossibleSeqColExtendedData(GCA_ACCESSION);
+        assertTrue(fetchSeqColData.isPresent());
+        assertFalse(fetchSeqColData.get().get("namesAttributes").isEmpty());
+        // We can retrieve sequences with two naming convention from this assembly report ('GCA_ACCESSION')
+        // Which are GENBANK and UCSC
+        assertTrue(fetchSeqColData.get().get("namesAttributes").size() == 2);
     }
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColExtendedDataServiceTest.java
@@ -113,7 +113,7 @@ class SeqColExtendedDataServiceTest {
         assertNotNull(assemblyEntity);
         assertEquals(assemblySequenceEntity.getSequences().size(), assemblyEntity.getChromosomes().size());
         SeqColExtendedDataEntity seqColLengthsObject = SeqColExtendedDataEntity.constructSeqColLengthsObject(assemblyEntity);
-        SeqColExtendedDataEntity seqColNamesObject = SeqColExtendedDataEntity.constructSeqColNamesObject(assemblyEntity, SeqColEntity.NamingConvention.GENBANK);
+        SeqColExtendedDataEntity seqColNamesObject = SeqColExtendedDataEntity.constructSeqColNamesObjectByNamingConvention(assemblyEntity, SeqColEntity.NamingConvention.GENBANK);
         SeqColExtendedDataEntity seqColSequencesObject = SeqColExtendedDataEntity.constructSeqColSequencesObject(assemblySequenceEntity);
         Optional<SeqColExtendedDataEntity> fetchNamesEntity = extendedDataService.addSeqColExtendedData(seqColLengthsObject);
         Optional<SeqColExtendedDataEntity> fetchLengthsEntity = extendedDataService.addSeqColExtendedData(seqColNamesObject);

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -137,10 +137,4 @@ class SeqColServiceTest {
         Optional<SeqColLevelTwoEntity> levelTwoEntity = (Optional<SeqColLevelTwoEntity>) seqColService.getSeqColByDigestAndLevel(TEST_DIGEST, 2);
         assertTrue(levelTwoEntity.isPresent());
     }
-
-    @Test
-    void fetchAndInsertAllPossibleSeqColsByAssemblyAccession() throws IOException {
-        List<String> insertedSeqColDigests = seqColService.fetchAndInsertAllSeqColByAssemblyAccession(GCA_ACCESSION);
-        assertEquals(2, insertedSeqColDigests.size());
-    }
 }

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColServiceTest.java
@@ -137,4 +137,10 @@ class SeqColServiceTest {
         Optional<SeqColLevelTwoEntity> levelTwoEntity = (Optional<SeqColLevelTwoEntity>) seqColService.getSeqColByDigestAndLevel(TEST_DIGEST, 2);
         assertTrue(levelTwoEntity.isPresent());
     }
+
+    @Test
+    void fetchAndInsertAllPossibleSeqColsByAssemblyAccession() throws IOException {
+        List<String> insertedSeqColDigests = seqColService.fetchAndInsertAllSeqColByAssemblyAccession(GCA_ACCESSION);
+        assertEquals(2, insertedSeqColDigests.size());
+    }
 }


### PR DESCRIPTION
Now we can fetch and insert all possible seqCol objects from one assembly read.
**Note:** "all possible" means with all the naming conventions that are provided in the assembly report.