### PR TITLE
Change json attribute name - md5-sequences

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelTwoEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelTwoEntity.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.eva.evaseqcol.entities;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,8 @@ public class SeqColLevelTwoEntity extends SeqColEntity{
     private List<String> sequences;
     private List<String> names;
     private List<String> lengths;
-    private List<String> md5Sequences;
+    @JsonProperty("md5-sequences")
+    private List<String> md5DigestsOfSequences;
 
     public SeqColLevelTwoEntity setDigest(String digest) {
         this.digest = digest;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -96,7 +96,7 @@ public class SeqColLevelOneService {
         JSONExtData sequencesExtData = new JSONExtData(levelTwoEntity.getSequences());
         JSONExtData lengthsExtData = new JSONExtData(levelTwoEntity.getLengths());
         JSONExtData namesExtData = new JSONExtData(levelTwoEntity.getNames());
-        JSONExtData md5SequencesExtData = new JSONExtData(levelTwoEntity.getMd5Sequences());
+        JSONExtData md5SequencesExtData = new JSONExtData(levelTwoEntity.getMd5DigestsOfSequences());
 
         // Sequences
         SeqColExtendedDataEntity sequencesExtEntity = new SeqColExtendedDataEntity();

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelTwoService.java
@@ -46,7 +46,7 @@ public class SeqColLevelTwoService {
                     levelTwoEntity.setSequences(extendedData.getExtendedSeqColData().getObject());
                     break;
                 case md5DigestsOfSequences:
-                    levelTwoEntity.setMd5Sequences(extendedData.getExtendedSeqColData().getObject());
+                    levelTwoEntity.setMd5DigestsOfSequences(extendedData.getExtendedSeqColData().getObject());
                     break;
             }
         }
@@ -104,7 +104,7 @@ public class SeqColLevelTwoService {
                     levelTwoEntity.setSequences(extendedData.getExtendedSeqColData().getObject());
                     break;
                 case md5DigestsOfSequences:
-                    levelTwoEntity.setMd5Sequences(extendedData.getExtendedSeqColData().getObject());
+                    levelTwoEntity.setMd5DigestsOfSequences(extendedData.getExtendedSeqColData().getObject());
                     break;
             }
         }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -83,7 +83,7 @@ public class SeqColService {
            JSONExtData extendedNames = extendedDataService.getSeqColExtendedDataEntityByDigest(namesDigest).get().getExtendedSeqColData();
 
            levelTwoEntity.setSequences(extendedSequences.getObject());
-           levelTwoEntity.setMd5Sequences(extendedMd5Sequnces.getObject());
+           levelTwoEntity.setMd5DigestsOfSequences(extendedMd5Sequnces.getObject());
            levelTwoEntity.setLengths(extendedLengths.getObject());
            levelTwoEntity.setNames(extendedNames.getObject());
 

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/utils/JSONLevelOne.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/utils/JSONLevelOne.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.eva.evaseqcol.utils;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import java.io.Serializable;
 @NoArgsConstructor
 public class JSONLevelOne implements Serializable {
     private String sequences;
+    @JsonProperty("md5-sequences")
     private String md5DigestsOfSequences;
     private String names;
     private String lengths;


### PR DESCRIPTION
Added the `@JsonProperty` annotation to distinguish between the java attribute naming and the seqcol-spec JSON attribute naming.