### PR TITLE
Implemented the service-info endpoint

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
@@ -13,12 +13,15 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
+import uk.ac.ebi.eva.evaseqcol.exception.UnableToLoadServiceInfoException;
 import uk.ac.ebi.eva.evaseqcol.service.SeqColService;
 
+import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/collection")
+@RequestMapping("/")
 public class SeqColController {
 
     private SeqColService seqColService;
@@ -28,7 +31,7 @@ public class SeqColController {
         this.seqColService = seqColService;
     }
 
-    @GetMapping(value = "/{digest}")
+    @GetMapping(value = "/collection/{digest}")
     public ResponseEntity<?> getSeqColByDigestAndLevel(
             @PathVariable String digest, @RequestParam(required = false) String level) {
         if (level == null) level = "none";
@@ -60,4 +63,13 @@ public class SeqColController {
         return new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
+    @GetMapping("/service-info")
+    public ResponseEntity<?> getServiceInfo() {
+        try {
+            Map<String, Object> serviceInfoMap = seqColService.getServiceInfo();
+            return new ResponseEntity<>(serviceInfoMap, HttpStatus.OK);
+        } catch (UnableToLoadServiceInfoException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColId.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColId.java
@@ -1,11 +1,13 @@
 package uk.ac.ebi.eva.evaseqcol.entities;
 
 import com.sun.istack.NotNull;
+import lombok.EqualsAndHashCode;
 
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import java.io.Serializable;
 
+@EqualsAndHashCode
 public class SeqColId implements Serializable {
     @NotNull
     private String digest;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/UnableToLoadServiceInfoException.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/UnableToLoadServiceInfoException.java
@@ -1,0 +1,8 @@
+package uk.ac.ebi.eva.evaseqcol.exception;
+
+public class UnableToLoadServiceInfoException extends RuntimeException {
+
+    public UnableToLoadServiceInfoException(String serviceInfoFilePath) {
+        super("Unable to load service-info file: " + serviceInfoFilePath);
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -115,7 +115,8 @@ public class SeqColService {
 
     /**
      * Return the service info entity in a Map<String,Object> format
-     * @see "https://seqcol.readthedocs.io/en/dev/specification/#21-service-info" for more details*/
+     * @see 'https://seqcol.readthedocs.io/en/dev/specification/#21-service-info'
+     * for more details about the service-info*/
     public Map<String, Object> getServiceInfo() {
         try {
             Map<String, Object> serviceInfoMap = SeqColMapConverter.jsonToMap(SERVICE_INFO_FILE_PATH);

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.eva.evaseqcol.service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,7 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColException;
 import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
+import uk.ac.ebi.eva.evaseqcol.exception.UnableToLoadServiceInfoException;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 import uk.ac.ebi.eva.evaseqcol.utils.SeqColMapConverter;
 
@@ -36,6 +38,8 @@ import java.util.stream.Collectors;
 @Service
 public class SeqColService {
 
+    @Value("${service.info.file.path}")
+    private String SERVICE_INFO_FILE_PATH;
     private final NCBISeqColDataSource ncbiSeqColDataSource;
     private final SeqColLevelOneService levelOneService;
     private final SeqColLevelTwoService levelTwoService;
@@ -107,6 +111,18 @@ public class SeqColService {
            logger.error("Could not find any seqCol object with digest " + digest + " on level " + level);
            return Optional.empty();
        }
+    }
+
+    /**
+     * Return the service info entity in a Map<String,Object> format
+     * @see "https://seqcol.readthedocs.io/en/dev/specification/#21-service-info" for more details*/
+    public Map<String, Object> getServiceInfo() {
+        try {
+            Map<String, Object> serviceInfoMap = SeqColMapConverter.jsonToMap(SERVICE_INFO_FILE_PATH);
+            return serviceInfoMap;
+        } catch (IOException e) {
+            throw new UnableToLoadServiceInfoException(SERVICE_INFO_FILE_PATH);
+        }
     }
 
     /**

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/utils/SeqColMapConverter.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/utils/SeqColMapConverter.java
@@ -1,10 +1,13 @@
 package uk.ac.ebi.eva.evaseqcol.utils;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -34,4 +37,18 @@ public class SeqColMapConverter {
         return seqColMap;
     }
 
+    /**
+     * Read the json file for the given filePath and return Map representation of
+     * its content*/
+    public static Map<String, Object> jsonToMap(String filePath) throws IOException {
+        File file = new File(filePath);
+        Map<String, Object> jsonMap = null;
+
+
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        jsonMap=mapper.readValue(file, Map.class);
+
+        return jsonMap;
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,7 @@ ftp.proxy.port=@ftp.proxy.port@
 config.scaffolds.enabled = @contig-alias.scaffolds-enabled@
 
 asm.file.download.dir=/tmp
+service.info.file.path=src/main/resources/static/service-info.json
 
 # remove spring data browsing endpoints (https://docs.spring.io/spring-data/rest/docs/3.3.x/reference/html/#getting-started.setting-repository-detection-strategy)
 spring.data.rest.detection-strategy=annotated

--- a/src/main/resources/static/service-info.json
+++ b/src/main/resources/static/service-info.json
@@ -4,7 +4,7 @@
   "type": {
     "group": "org.ga4gh",
     "artifact": "seqcol",
-    "version": "0.0.0"
+    "version": "1.0.0"
   },
   "organization": {
     "name": "European Variation Archive",
@@ -14,7 +14,7 @@
   "documentationUrl": "https://www.ebi.ac.uk/eva/....",
   "updatedAt": "08-24-2023",
   "environment": "dev",
-  "version": "tagged version",
+  "version": "1.0.0",
   "seqcol": {
     "schema": {
       "description": "A collection of sequences, representing biological sequences including nucleotide or amino acid sequences. For example, a sequence collection may represent the set of chromosomes in a reference genome, the set of transcripts in a transcriptome, a collection of reference microbial sequences of a specific gene, or any other set of sequences.",
@@ -44,7 +44,7 @@
             "type": "string"
           }
         },
-        "md5_sequences":{
+        "md5-sequences":{
           "type": "array",
           "description": "Digests of sequences computed using md5 digest algorithm.",
           "collated": "true",
@@ -52,9 +52,9 @@
             "type": "string"
           }
         },
-        "sorted_names_length_pairs":{
+        "sorted-name-length-pairs":{
           "type": "array",
-          "description": "objects composed of length and name of a sequence digested and ordered lexicographically",
+          "description": "Objects composed of length and name of a sequence digested and ordered lexicographically",
           "collated": "false",
           "items":{
             "type": "string"

--- a/src/main/resources/static/service-info.json
+++ b/src/main/resources/static/service-info.json
@@ -1,0 +1,77 @@
+{
+  "id": "uk.ebi.eva.eva-seqcol",
+  "name": "Implementation of the GA4GH Sequence collection retrieval API",
+  "type": {
+    "group": "org.ga4gh",
+    "artifact": "seqcol",
+    "version": "0.0.0"
+  },
+  "organization": {
+    "name": "European Variation Archive",
+    "url": "https://www.ebi.ac.uk/eva"
+  },
+  "contactUrl": "mailto:eva-helpdesk@ebi.ac.uk",
+  "documentationUrl": "https://www.ebi.ac.uk/eva/....",
+  "updatedAt": "08-24-2023",
+  "environment": "dev",
+  "version": "tagged version",
+  "seqcol": {
+    "schema": {
+      "description": "A collection of sequences, representing biological sequences including nucleotide or amino acid sequences. For example, a sequence collection may represent the set of chromosomes in a reference genome, the set of transcripts in a transcriptome, a collection of reference microbial sequences of a specific gene, or any other set of sequences.",
+      "type": "object",
+      "properties":{
+        "lengths":{
+          "type": "array",
+          "description": "Number of elements, such as nucleotides or amino acids, in each sequence.",
+          "collated": "true",
+          "items":{
+            "type": "string"
+          }
+        },
+        "names":{
+          "type": "array",
+          "description": "Human-readable identifiers of each sequence, commonly called chromosome names.",
+          "collated": "true",
+          "items":{
+            "type": "string"
+          }
+        },
+        "sequences":{
+          "type": "array",
+          "description": "Digests of sequences computed using the GA4GH digest algorithm (sha512t24u).",
+          "collated": "true",
+          "items":{
+            "type": "string"
+          }
+        },
+        "md5_sequences":{
+          "type": "array",
+          "description": "Digests of sequences computed using md5 digest algorithm.",
+          "collated": "true",
+          "items":{
+            "type": "string"
+          }
+        },
+        "sorted_names_length_pairs":{
+          "type": "array",
+          "description": "objects composed of length and name of a sequence digested and ordered lexicographically",
+          "collated": "false",
+          "items":{
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "names",
+        "lengths",
+        "sequences"
+      ],
+      "inherent":[
+        "names",
+        "lengths",
+        "sequences"
+      ]
+    }
+  }
+}
+

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/utils/SeqColMapConverterTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/utils/SeqColMapConverterTest.java
@@ -1,12 +1,14 @@
 package uk.ac.ebi.eva.evaseqcol.utils;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
 import uk.ac.ebi.eva.evaseqcol.io.SeqColGenerator;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -18,6 +20,9 @@ class SeqColMapConverterTest {
     private SeqColMapConverter seqColMapConverter = new SeqColMapConverter();
 
     private SeqColGenerator seqColGenerator = new SeqColGenerator();
+
+    @Value("${service.info.file.path}")
+    private String serviceInfoFilePath;
 
     @Test
     void setSeqColLevelOneMapConverterTest() {
@@ -43,5 +48,11 @@ class SeqColMapConverterTest {
         assertNotNull(levelTwoMap.get("sequences"));
         assertNotNull(levelTwoMap.get("lengths"));
         assertNotNull(levelTwoMap.get("names"));
+    }
+
+    @Test
+    void jsonToMapTest() throws IOException {
+        Map<String, Object> serviceInfoMap = SeqColMapConverter.jsonToMap(serviceInfoFilePath);
+        assertNotNull(serviceInfoMap);
     }
 }


### PR DESCRIPTION
closes #37 
Implemented the **service-info** endpoint.
I actually used the same file provided [here](https://github.com/EBIvariation/eva-seqcol/issues/37) by @tcezard.

I did one change in the `lengths` attribute's type that I changed it into `string`, which is how it is defined in our API, and we'll consider updating it into `integer` after we do the refactor in our API.

I would like to know whether we should use `sorted_names_length_pairs`, as provided in the service-info file, or `sorted_name_length_pairs` as we defined it in our java model.