### PR TITLE
fixed the level 1 representation for the get endpoint

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
@@ -58,7 +58,7 @@ public class SeqColController {
                 case "1":
                     Optional<SeqColLevelOneEntity> levelOneEntity = (Optional<SeqColLevelOneEntity>) seqColService.getSeqColByDigestAndLevel(digest, 1);
                     if (levelOneEntity.isPresent()) {
-                        return ResponseEntity.ok(levelOneEntity.get());
+                        return ResponseEntity.ok(levelOneEntity.get().getSeqColLevel1Object());
                     }
                     break;
                 case "2":

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/SeqColControllerIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/SeqColControllerIntegrationTest.java
@@ -83,7 +83,8 @@ public class SeqColControllerIntegrationTest {
         Map<String, List<String>> levelTwoEntity = restTemplate.getForObject(finalRequest + level_2_path, Map.class);
         assertNotNull(levelOneEntity);
         assertNotNull(levelTwoEntity);
-        assertNotNull(levelOneEntity.get("digest"));
+        assertNotNull(levelTwoEntity.get("names"));
+        assertNotNull(levelOneEntity.get("lengths"));
         assertNotNull(levelTwoEntity.get("sequences"));
     }
 


### PR DESCRIPTION
fixes #48 
The refactor was straightforward, because we coded the seqcol level attributes in a separate class: `JSONLevelOne`, and it is separated from the meta-data, like the `naming_convention`, and `digest`.

The output of the GET (retrieval) endpoint with `level=1` is now:
```json
{
    "sequences": "dda3Kzi1Wkm2A8I99WietU1R8J4PL-D6",
    "names": "mfxUkK3J5y7BGVW7hJWcJ3erxuaMX6xm",
    "lengths": "Ms_ixPgQMJaM54dVntLWeovXSO7ljvZh",
    "md5-sequences": "_6iaYtcWw4TZaowlL7_64Wu9mbHpDUw4",
    "sorted-name-length-pairs": "Yz3kB58sQCEWKRbx9KOW5x6Gc7OJlgIs"
}
```

Note: we fixed the hyphen convention-underscore convention in another PR.

### Suggestion
We can add another endpoint that gives the user the possibility to fetch the seqcol object with other **metadata**.

So the new endpoint may be like:
-  ../collection/{digest}/metadata
- or ../collection/{digest}/extended
- or ../collection/{digest}?level=1&moreInfo=1

A discussion must be done to choose the best endpoint schema