### PR TITLE
reset the maven.yml file: remvoing the refactor branch form the list

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,7 +6,7 @@ name: Java CI with Maven
 on:
   push:
   pull_request:
-    branches: [ "main", "refactor"]
+    branches: ["main"]
 
 jobs:
   build:


### PR DESCRIPTION
This PR will take us the previous state of the `maven.yml` file. Because it seems that adding the `refactor` branch to the branches list didn't work for some reason.
I had to merge it previously in order to see it running on GitHub, however I could have test it differently. Sorry for this.