### PR TITLE
updated the comparison function format

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
@@ -2,7 +2,6 @@ package uk.ac.ebi.eva.evaseqcol.entities;
 
 import lombok.Data;
 
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
@@ -17,13 +17,13 @@ public class SeqColComparisonResultEntity {
     private SortedMap<String, String> digests;
 
     /**
-     * The "arrays" attribute contains three sub-attributes:
+     * The "attributes" attribute contains three sub-attributes:
      *  "a_only", "b_only", "a_and_b"*/
     private SortedMap<String, List<String>> attributes;
 
     /**
-     * The "elements" attribute contains three sub-attributes:
-     *  "total", "a_and_b", "a_and_b_same_order"*/
+     * The "array_elements" attribute contains four sub-attributes:
+     *  "a_count", "b_count", "a_and_b_count", "a_and_b_same_order"*/
     private HashMap<String, TreeMap<String, Object>> array_elements; // The object can be either Integer or Boolean
 
 
@@ -31,9 +31,9 @@ public class SeqColComparisonResultEntity {
         this.digests = new TreeMap<>();
         this.attributes = new TreeMap<>();
         this.array_elements = new LinkedHashMap<>();
-        array_elements.put("a", new TreeMap<>());
-        array_elements.put("b", new TreeMap<>());
-        array_elements.put("a_and_b", new TreeMap<>());
+        array_elements.put("a_count", new TreeMap<>());
+        array_elements.put("b_count", new TreeMap<>());
+        array_elements.put("a_and_b_count", new TreeMap<>());
         array_elements.put("a_and_b_same_order", new TreeMap<>());
 
     }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
@@ -2,11 +2,12 @@ package uk.ac.ebi.eva.evaseqcol.entities;
 
 import lombok.Data;
 
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.Map;
 
 @Data
 public class SeqColComparisonResultEntity {
@@ -19,21 +20,22 @@ public class SeqColComparisonResultEntity {
     /**
      * The "arrays" attribute contains three sub-attributes:
      *  "a_only", "b_only", "a_and_b"*/
-    private SortedMap<String, List<String>> arrays;
+    private SortedMap<String, List<String>> attributes;
 
     /**
      * The "elements" attribute contains three sub-attributes:
      *  "total", "a_and_b", "a_and_b_same_order"*/
-    private SortedMap<String, SortedMap<String, Object>> elements; // The object can be either Integer or Boolean
+    private HashMap<String, TreeMap<String, Object>> array_elements; // The object can be either Integer or Boolean
 
 
     public SeqColComparisonResultEntity() {
         this.digests = new TreeMap<>();
-        this.arrays = new TreeMap<>();
-        this.elements = new TreeMap<>();
-        elements.put("total", new TreeMap<>());
-        elements.put("a_and_b", new TreeMap<>());
-        elements.put("a_and_b_same_order", new TreeMap<>());
+        this.attributes = new TreeMap<>();
+        this.array_elements = new LinkedHashMap<>();
+        array_elements.put("a", new TreeMap<>());
+        array_elements.put("b", new TreeMap<>());
+        array_elements.put("a_and_b", new TreeMap<>());
+        array_elements.put("a_and_b_same_order", new TreeMap<>());
 
     }
 
@@ -45,11 +47,11 @@ public class SeqColComparisonResultEntity {
     }
 
     public void putIntoArrays(String key, List<String> value) {
-        arrays.put(key, value);
+        attributes.put(key, value);
     }
 
-    public void putIntoElements(String elementName,String key, Object value) {
-        SortedMap<String, Object> elementsMap = elements.get(elementName);
-        elementsMap.put(key, value);
+    public void putIntoArrayElements(String elementName, String key, Object value) {
+        SortedMap<String, Object> arrayElementsMap = array_elements.get(elementName);
+        arrayElementsMap.put(key, value);
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -315,20 +315,20 @@ public class SeqColService {
         // "array_elements" attribute | "a"
         for (String attribute: seqColAAttributeSet) {
             // Looping through each attribute of seqcolA, Eg: "sequences", "lengths", etc...
-            comparisonResult.putIntoArrayElements("a", attribute, seqColAEntityMap.get(attribute).size());
+            comparisonResult.putIntoArrayElements("a_count", attribute, seqColAEntityMap.get(attribute).size());
         }
 
         // "array_elements" attribute | "b"
         for (String attribute: seqColBAttributeSet) {
             // Looping through each attribute of seqcolB, Eg: "sequences", "lengths", etc...
-            comparisonResult.putIntoArrayElements("b", attribute, seqColBEntityMap.get(attribute).size());
+            comparisonResult.putIntoArrayElements("b_count", attribute, seqColBEntityMap.get(attribute).size());
         }
 
         // "array_elements" attribute | "a_and_b"
         List<String> commonSeqColAttributesValues = getCommonElementsDistinct(seqColAAttributesList, seqColBAttributesList); // eg: ["sequences", "lengths", ...]
         for (String element: commonSeqColAttributesValues) {
             Integer commonElementsCount = getCommonElementsCount(seqColAEntityMap.get(element), seqColBEntityMap.get(element));
-            comparisonResult.putIntoArrayElements("a_and_b", element, commonElementsCount);
+            comparisonResult.putIntoArrayElements("a_and_b_count", element, commonElementsCount);
         }
 
         // "array_elements" attribute | "a_and_b_same_order"

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -312,27 +312,33 @@ public class SeqColService {
         comparisonResult.putIntoArrays("b_only", seqColBUniqueAttributes);
         comparisonResult.putIntoArrays("a_and_b", seqColCommonAttributes);
 
-        // "elements" attribute | "total"
-        Integer seqColATotal = seqColAEntityMap.get("lengths").size();
-        Integer seqColBTotal = seqColBEntityMap.get("lengths").size();
-        comparisonResult.putIntoElements("total", "a", seqColATotal);
-        comparisonResult.putIntoElements("total", "b", seqColBTotal);
+        // "array_elements" attribute | "a"
+        for (String attribute: seqColAAttributeSet) {
+            // Looping through each attribute of seqcolA, Eg: "sequences", "lengths", etc...
+            comparisonResult.putIntoArrayElements("a", attribute, seqColAEntityMap.get(attribute).size());
+        }
 
-        // "elements" attribute | "a_and_b"
+        // "array_elements" attribute | "b"
+        for (String attribute: seqColBAttributeSet) {
+            // Looping through each attribute of seqcolB, Eg: "sequences", "lengths", etc...
+            comparisonResult.putIntoArrayElements("b", attribute, seqColBEntityMap.get(attribute).size());
+        }
+
+        // "array_elements" attribute | "a_and_b"
         List<String> commonSeqColAttributesValues = getCommonElementsDistinct(seqColAAttributesList, seqColBAttributesList); // eg: ["sequences", "lengths", ...]
         for (String element: commonSeqColAttributesValues) {
             Integer commonElementsCount = getCommonElementsCount(seqColAEntityMap.get(element), seqColBEntityMap.get(element));
-            comparisonResult.putIntoElements("a_and_b", element, commonElementsCount);
+            comparisonResult.putIntoArrayElements("a_and_b", element, commonElementsCount);
         }
 
-        // "elements" attribute | "a_and_b_same_order"
+        // "array_elements" attribute | "a_and_b_same_order"
         for (String attribute: commonSeqColAttributesValues) {
             if (lessThanTwoOverlappingElements(seqColAEntityMap.get(attribute), seqColBEntityMap.get(attribute))
                     || unbalancedDuplicatesPresent(seqColAEntityMap.get(attribute), seqColBEntityMap.get(attribute))){
-                comparisonResult.putIntoElements("a_and_b_same_order", attribute, null);
+                comparisonResult.putIntoArrayElements("a_and_b_same_order", attribute, null);
             } else {
                 boolean attributeSameOrder = check_A_And_B_Same_Order(seqColAEntityMap.get(attribute), seqColBEntityMap.get(attribute));
-                comparisonResult.putIntoElements("a_and_b_same_order", attribute, attributeSameOrder);
+                comparisonResult.putIntoArrayElements("a_and_b_same_order", attribute, attributeSameOrder);
             }
         }
 

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/SeqColComparisonControllerIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/SeqColComparisonControllerIntegrationTest.java
@@ -83,8 +83,8 @@ public class SeqColComparisonControllerIntegrationTest {
         Map<String, Object> comparisonResult = restTemplate.getForObject(finalRequest, Map.class);
         assertNotNull(comparisonResult);
         assertNotNull(comparisonResult.get("digests"));
-        assertNotNull(comparisonResult.get("arrays"));
-        assertNotNull(comparisonResult.get("elements"));
+        assertNotNull(comparisonResult.get("attributes"));
+        assertNotNull(comparisonResult.get("array_elements"));
     }
 
     @Test
@@ -97,7 +97,7 @@ public class SeqColComparisonControllerIntegrationTest {
         Map<String, Object> comparisonResult = restTemplate.postForObject(finlRequest, seqColLevelTwoPostBody, Map.class);
         assertNotNull(comparisonResult);
         assertNotNull(comparisonResult.get("digests"));
-        assertNotNull(comparisonResult.get("arrays"));
-        assertNotNull(comparisonResult.get("elements"));
+        assertNotNull(comparisonResult.get("attributes"));
+        assertNotNull(comparisonResult.get("array_elements"));
     }
 }


### PR DESCRIPTION
closes #71 
Updated the comparison function format as discussed in issue #71 .

The new comparison result of comparing these two seqcol objects: `3mTg0tAA3PS-R1TzelLVWJ2ilUzoWfVq` and `rkTW1yZ0e22IN8K-0frqoGOMT8dynNyE` is :

```json 
{
    "digests": {
        "a": "3mTg0tAA3PS-R1TzelLVWJ2ilUzoWfVq",
        "b": "rkTW1yZ0e22IN8K-0frqoGOMT8dynNyE"
    },
    "attributes": {
        "a_and_b": [
            "sequences",
            "names",
            "lengths",
            "md5_sequences",
            "sorted_name_length_pairs"
        ],
        "a_only": [],
        "b_only": []
    },
    "array_elements": {
        "a": {
            "lengths": 16,
            "md5_sequences": 16,
            "names": 16,
            "sequences": 16,
            "sorted_name_length_pairs": 16
        },
        "b": {
            "lengths": 16,
            "md5_sequences": 16,
            "names": 16,
            "sequences": 16,
            "sorted_name_length_pairs": 16
        },
        "a_and_b": {
            "lengths": 16,
            "md5_sequences": 16,
            "names": 0,
            "sequences": 16,
            "sorted_name_length_pairs": 0
        },
        "a_and_b_same_order": {
            "lengths": true,
            "md5_sequences": true,
            "names": null,
            "sequences": true,
            "sorted_name_length_pairs": null
        }
    }
}
```

Implemented the logic described [here](https://github.com/EBIvariation/eva-seqcol/issues/71#issuecomment-1867696853).