### PR TITLE
Checking for undefined attributes that could be sent by the user in the comparison POST request

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
@@ -2,7 +2,6 @@ package uk.ac.ebi.eva.evaseqcol.entities;
 
 import lombok.Data;
 
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColComparisonResultEntity.java
@@ -2,11 +2,12 @@ package uk.ac.ebi.eva.evaseqcol.entities;
 
 import lombok.Data;
 
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.Map;
 
 @Data
 public class SeqColComparisonResultEntity {
@@ -19,21 +20,22 @@ public class SeqColComparisonResultEntity {
     /**
      * The "arrays" attribute contains three sub-attributes:
      *  "a_only", "b_only", "a_and_b"*/
-    private SortedMap<String, List<String>> arrays;
+    private SortedMap<String, List<String>> attributes;
 
     /**
      * The "elements" attribute contains three sub-attributes:
      *  "total", "a_and_b", "a_and_b_same_order"*/
-    private SortedMap<String, SortedMap<String, Object>> elements; // The object can be either Integer or Boolean
+    private HashMap<String, TreeMap<String, Object>> array_elements; // The object can be either Integer or Boolean
 
 
     public SeqColComparisonResultEntity() {
         this.digests = new TreeMap<>();
-        this.arrays = new TreeMap<>();
-        this.elements = new TreeMap<>();
-        elements.put("total", new TreeMap<>());
-        elements.put("a_and_b", new TreeMap<>());
-        elements.put("a_and_b_same_order", new TreeMap<>());
+        this.attributes = new TreeMap<>();
+        this.array_elements = new LinkedHashMap<>();
+        array_elements.put("a", new TreeMap<>());
+        array_elements.put("b", new TreeMap<>());
+        array_elements.put("a_and_b", new TreeMap<>());
+        array_elements.put("a_and_b_same_order", new TreeMap<>());
 
     }
 
@@ -45,11 +47,11 @@ public class SeqColComparisonResultEntity {
     }
 
     public void putIntoArrays(String key, List<String> value) {
-        arrays.put(key, value);
+        attributes.put(key, value);
     }
 
-    public void putIntoElements(String elementName,String key, Object value) {
-        SortedMap<String, Object> elementsMap = elements.get(elementName);
-        elementsMap.put(key, value);
+    public void putIntoArrayElements(String elementName, String key, Object value) {
+        SortedMap<String, Object> arrayElementsMap = array_elements.get(elementName);
+        arrayElementsMap.put(key, value);
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColExtendedDataEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColExtendedDataEntity.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
 import uk.ac.ebi.eva.evaseqcol.digests.DigestCalculator;
+import uk.ac.ebi.eva.evaseqcol.exception.AttributeNotDefinedException;
 import uk.ac.ebi.eva.evaseqcol.model.NameLengthPairEntity;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONExtData;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONIntegerListExtData;
@@ -71,7 +72,7 @@ public class SeqColExtendedDataEntity<T> {
                     return b;
                 }
             }
-            throw new IllegalArgumentException("No seqcol attribute with value " + attrVal + " found");
+            throw new AttributeNotDefinedException("No seqcol attribute with value \"" + attrVal + "\" found");
         }
     }
 

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/AttributeNotDefinedException.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/AttributeNotDefinedException.java
@@ -1,0 +1,11 @@
+package uk.ac.ebi.eva.evaseqcol.exception;
+
+/**
+ * This exception should be thrown when an undefined seqcol attribute has
+ * been given (normally by the user in the POST comparison request's body)*/
+public class AttributeNotDefinedException extends RuntimeException{
+
+    public AttributeNotDefinedException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -14,6 +14,7 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColExtendedDataEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
+import uk.ac.ebi.eva.evaseqcol.exception.AttributeNotDefinedException;
 import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColException;
 import uk.ac.ebi.eva.evaseqcol.exception.SeqColNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.exception.UnableToLoadServiceInfoException;
@@ -377,12 +378,16 @@ public class SeqColService {
         Map<String, String> seqColL1Map = new TreeMap<>();
         Set<String> seqColAttributes = seqColL2Map.keySet(); // The set of the seqCol attributes ("lengths", "sequences", etc.)
         for (String attribute: seqColAttributes) {
-            String attributeDigest;
-            attributeDigest= digestCalculator.getSha512Digest(
-                    convertSeqColLevelTwoAttributeValuesToString(seqColL2Map.get(attribute),
-                                                                 SeqColExtendedDataEntity.AttributeType.fromAttributeVal(
-                                                                         attribute)));
-            seqColL1Map.put(attribute, attributeDigest);
+            try {
+                String attributeDigest;
+                attributeDigest= digestCalculator.getSha512Digest(
+                        convertSeqColLevelTwoAttributeValuesToString(seqColL2Map.get(attribute),
+                                                                     SeqColExtendedDataEntity.AttributeType.fromAttributeVal(
+                                                                             attribute)));
+                seqColL1Map.put(attribute, attributeDigest);
+            } catch (AttributeNotDefinedException e) {
+                logger.warn(e.getMessage());
+            }
         }
         return seqColL1Map;
     }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -312,27 +312,33 @@ public class SeqColService {
         comparisonResult.putIntoArrays("b_only", seqColBUniqueAttributes);
         comparisonResult.putIntoArrays("a_and_b", seqColCommonAttributes);
 
-        // "elements" attribute | "total"
-        Integer seqColATotal = seqColAEntityMap.get("lengths").size();
-        Integer seqColBTotal = seqColBEntityMap.get("lengths").size();
-        comparisonResult.putIntoElements("total", "a", seqColATotal);
-        comparisonResult.putIntoElements("total", "b", seqColBTotal);
+        // "array_elements" attribute | "a"
+        for (String attribute: seqColAAttributeSet) {
+            // Looping through each attribute of seqcolA, Eg: "sequences", "lengths", etc...
+            comparisonResult.putIntoArrayElements("a", attribute, seqColAEntityMap.get(attribute).size());
+        }
 
-        // "elements" attribute | "a_and_b"
+        // "array_elements" attribute | "b"
+        for (String attribute: seqColBAttributeSet) {
+            // Looping through each attribute of seqcolB, Eg: "sequences", "lengths", etc...
+            comparisonResult.putIntoArrayElements("b", attribute, seqColBEntityMap.get(attribute).size());
+        }
+
+        // "array_elements" attribute | "a_and_b"
         List<String> commonSeqColAttributesValues = getCommonElementsDistinct(seqColAAttributesList, seqColBAttributesList); // eg: ["sequences", "lengths", ...]
         for (String element: commonSeqColAttributesValues) {
             Integer commonElementsCount = getCommonElementsCount(seqColAEntityMap.get(element), seqColBEntityMap.get(element));
-            comparisonResult.putIntoElements("a_and_b", element, commonElementsCount);
+            comparisonResult.putIntoArrayElements("a_and_b", element, commonElementsCount);
         }
 
-        // "elements" attribute | "a_and_b_same_order"
+        // "array_elements" attribute | "a_and_b_same_order"
         for (String attribute: commonSeqColAttributesValues) {
             if (lessThanTwoOverlappingElements(seqColAEntityMap.get(attribute), seqColBEntityMap.get(attribute))
                     || unbalancedDuplicatesPresent(seqColAEntityMap.get(attribute), seqColBEntityMap.get(attribute))){
-                comparisonResult.putIntoElements("a_and_b_same_order", attribute, null);
+                comparisonResult.putIntoArrayElements("a_and_b_same_order", attribute, null);
             } else {
                 boolean attributeSameOrder = check_A_And_B_Same_Order(seqColAEntityMap.get(attribute), seqColBEntityMap.get(attribute));
-                comparisonResult.putIntoElements("a_and_b_same_order", attribute, attributeSameOrder);
+                comparisonResult.putIntoArrayElements("a_and_b_same_order", attribute, attributeSameOrder);
             }
         }
 

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/SeqColComparisonControllerIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/SeqColComparisonControllerIntegrationTest.java
@@ -83,8 +83,8 @@ public class SeqColComparisonControllerIntegrationTest {
         Map<String, Object> comparisonResult = restTemplate.getForObject(finalRequest, Map.class);
         assertNotNull(comparisonResult);
         assertNotNull(comparisonResult.get("digests"));
-        assertNotNull(comparisonResult.get("arrays"));
-        assertNotNull(comparisonResult.get("elements"));
+        assertNotNull(comparisonResult.get("attributes"));
+        assertNotNull(comparisonResult.get("array_elements"));
     }
 
     @Test
@@ -97,7 +97,7 @@ public class SeqColComparisonControllerIntegrationTest {
         Map<String, Object> comparisonResult = restTemplate.postForObject(finlRequest, seqColLevelTwoPostBody, Map.class);
         assertNotNull(comparisonResult);
         assertNotNull(comparisonResult.get("digests"));
-        assertNotNull(comparisonResult.get("arrays"));
-        assertNotNull(comparisonResult.get("elements"));
+        assertNotNull(comparisonResult.get("attributes"));
+        assertNotNull(comparisonResult.get("array_elements"));
     }
 }


### PR DESCRIPTION
## Description
Currently, for the POST comparison endpoint, the seqcol service can only function when the user provides attributes that are already defined in our seqcol service implementation, and it will crash when the user provides an **undefined attribute** within the seqcol body.
So we're trying to make the service function even it gets undefined attributes from the user in the POST comparison endpoint request's body.
Fixes #70 
## Type of change
We'll be catching the exception thrown when the service tries to cast the undefined_attribute into a seqcol attribute of one of our implementation's in some of comparison result's parts, and ignore that attribute in that particular part.
**Note:** the attribute may be ignored for some parts of the comparison but it can appear in other parts (see the example below)
## New Comparison Result output example
When providing the following secol level 2 object in the comparison POST body:
```json
{
    "sequences": [
        "SQ.lZyxiD_ByprhOUzrR1o1bq0ezO_1gkrn",
        "SQ.vw8jTiV5SAPDH4TEIZhNGylzNsQM4NC9",
        "SQ.A_i2Id0FjBI-tQyU4ZaCEdxRzQheDevn",
        "SQ.QXSUMoZW_SSsCCN9_wc-xmubKQSOn3Qb",
        "SQ.UN_b-wij0EtsgFqQ2xNsbXs_GYQQIbeQ",
        "SQ.z-qJgWoacRBV77zcMgZN9E_utrdzmQsH",
        "SQ.9wkqGXgK6bvM0gcjBiTDk9tAaqOZojlR",
        "SQ.K8ln7Ygob_lcVjNh-C8kUydzZjRt3UDf",
        "SQ.hb1scjdCWL89PtAkR0AVH9-dNH5R0FsN",
        "SQ.DKiPmNQT_aUFndwpRiUbgkRj4DPHgGjd",
        "SQ.RwKcMXVadHZub1qL0Y5c1gmNU1_vHFme",
        "SQ.1sw7ZtgO9JRb1kUEuhVz1wBix5_8Opci",
        "SQ.V7DQqMKG7bcyxiMZK9wNjkK-udR7hrad",
        "SQ.R8nT1N2qQFMc_uVMQUVMw-D2GcVmb5v6",
        "SQ.DPa_ORXLkGyyCbW9SWeqePfortM-Vdlm",
        "SQ.koyLEKoDOQtGHjb4r0m3o2SXxI09Z_sI"
    ],
    "names": [
        "chrI",
        "chrII",
        "chrIII",
        "chrIV",
        "chrV",
        "chrVI",
        "chrVII",
        "chrVIII",
        "chrIX",
        "chrX",
        "chrXI",
        "chrXII",
        "chrXIII",
        "chrXIV",
        "chrXV",
        "chrXVI"
    ],
    "lengths": [
        230218,
        813184,
        316620,
        1531933,
        576874,
        270161,
        1090940,
        562643,
        439888,
        745751,
        666816,
        1078177,
        924431,
        784333,
        1091291,
        948066
    ],
    "md5_sequences": [
        "6681ac2f62509cfc220d78751b8dc524",
        "97a317c689cbdd7e92a5c159acd290d2",
        "54f4a74aa6392d9e19b82c38aa8ab345",
        "74180788027e20df3de53dcb2367d9e3",
        "d2787193198c8d260f58f2097f9e1e39",
        "b7ebc601f9a7df2e1ec5863deeae88a3",
        "a308c7ebf0b67c4926bc190dc4ba8ed8",
        "f66a4f8eef89fc3c3a393fe0210169f1",
        "4eae53ae7b2029b7e1075461c3eb9aac",
        "6757b8c7d9cca2c56401e2484cf5e2fb",
        "e72df2471be793f8aa06850348a896fa",
        "77945d734ab92ad527d8920c9d78ac1c",
        "073f9ff1c599c1a6867de2c7e4355394",
        "188bca5110182a786cd42686ec6882c6",
        "7e02090a38f05459102d1a9a83703534",
        "232475e9a61a5e07f9cb2df4a2dad757"
    ],
    "sorted_name_length_pairs": [
        "4KSEeZmiD9VkYC7ecIAsX7aXQggFwp9H",
        "B2VqaWiRary0j7btzmlGhNuoVPqlE21J",
        "d5VdLsb-kcdSepxl1dxSNk9KWEwL2bZ2",
        "FU4O09TlQ0Ls3f-kumtsnAag66MxsaNH",
        "H9xUzOT5xqMmL-Epq0qARIT3446kTZmR",
        "hio8YzqYfZVVMcINhQPDVd5xREYAMrzA",
        "kH3mpix7X2RAEENZYueDqxK0X5m06pan",
        "lKQL4D5qqnuToblXhGL1ZXMAuR6o6ng4",
        "NwP-e9miFDExu2aFejtku7KvmGGXla2R",
        "pFlAwWxDmSH9KkdK_yHBA0xtql0lSmTf",
        "QveClkmJYVlkucglvpJmON5uTL0Eu0No",
        "qWT4vrlChGgN5N_w3_-_NyQfkFxn98eN",
        "sdKiPkMb6nKtNfN_BP-X8284rdYQYDhM",
        "uKS-fRsOtAxqCTxktf6kUhwsBC9BMT9I",
        "w7OoScU_vDJJtw4UsGV_hd5u_je0fTei",
        "w8srPsF7XUe6GMvrLRI5gXX_DYAO3k_O"
    ],
    "new_attribute_1": [
        "1111111111111111",
        "2222222222222222",
        "3333333333333333",
        "aaaaaaaaaaaaaaaa",
        "bbbbbbbbbbbbbbbb"
    ],
    "new_attribute_2": ["New_attribute_val"]
}
```

We get the following **Comparison Result**:
```json
{
    "digests": {
        "a": "3mTg0tAA3PS-R1TzelLVWJ2ilUzoWfVq",
        "b": "rkTW1yZ0e22IN8K-0frqoGOMT8dynNyE"
    },
    "attributes": {
        "a_and_b": [
            "sequences",
            "names",
            "lengths",
            "md5_sequences",
            "sorted_name_length_pairs"
        ],
        "a_only": [],
        "b_only": [
            "new_attribute_1",
            "new_attribute_2"
        ]
    },
    "array_elements": {
        "a": {
            "lengths": 16,
            "md5_sequences": 16,
            "names": 16,
            "sequences": 16,
            "sorted_name_length_pairs": 16
        },
        "b": {
            "lengths": 16,
            "md5_sequences": 16,
            "names": 16,
            "new_attribute_1": 5,
            "new_attribute_2": 1,
            "sequences": 16,
            "sorted_name_length_pairs": 16
        },
        "a_and_b": {
            "lengths": 16,
            "md5_sequences": 16,
            "names": 0,
            "sequences": 16,
            "sorted_name_length_pairs": 0
        },
        "a_and_b_same_order": {
            "lengths": true,
            "md5_sequences": true,
            "names": null,
            "sequences": true,
            "sorted_name_length_pairs": null
        }
    }
}
```
 
We can see that `new_attribute_1` and `new_attribute_2` appear in some of the comparisonResult's body parts, and don't in other parts where they can't be compared to existing attributes of our implementation.

## Further discussion
@tcezard So in this PR we made the service able to accept undefined attributes from the user in the POST comparison request, but these attributes will only appear in some parts of the comparison result. 
Is this the right implementation or should we **completely ignore** the undefined attributes given in the comparison result body ? And in that case, what should be the output result (format) of that endpoint ?

## Note
This branch is a child of the one of #73, so I think it's better to merge that one first for easier review.