### PR TITLE
A proposal for the return type/object of the ingestion endpoint

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import uk.ac.ebi.eva.evaseqcol.exception.AssemblyAlreadyIngestedException;
 import uk.ac.ebi.eva.evaseqcol.exception.AssemblyNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColException;
 import uk.ac.ebi.eva.evaseqcol.exception.IncorrectAccessionException;
@@ -42,7 +43,7 @@ public class AdminController {
                     "contained in the assembly report) and eventually save these seqCol objects into the database. " +
                     "This is an authenticated endpoint, so it requires admin privileges to run it.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "seqCol object(s) successfully inserted"),
+            @ApiResponse(responseCode = "201", description = "seqCol object(s) successfully inserted"),
             @ApiResponse(responseCode = "409", description = "seqCol object(s) already exist(s)"),
             @ApiResponse(responseCode = "404", description = "Assembly not found"),
             @ApiResponse(responseCode = "400", description = "Bad request. (It can be a bad accession value)"),
@@ -56,7 +57,7 @@ public class AdminController {
             required = true) @PathVariable String asmAccession) {
         try {
             IngestionResultEntity ingestionResult = seqColService.fetchAndInsertAllSeqColByAssemblyAccession(asmAccession);
-            return ResponseEntity.ok(ingestionResult);
+            return new ResponseEntity<>(ingestionResult, HttpStatus.CREATED);
         } catch (IncorrectAccessionException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         } catch (IllegalArgumentException e) {
@@ -69,6 +70,8 @@ public class AdminController {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.CONFLICT);
         } catch (AssemblyNotFoundException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
+        } catch (AssemblyAlreadyIngestedException e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.CONFLICT);
         }
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.eva.evaseqcol.exception.AssemblyNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColException;
 import uk.ac.ebi.eva.evaseqcol.exception.IncorrectAccessionException;
+import uk.ac.ebi.eva.evaseqcol.model.IngestionResultEntity;
 import uk.ac.ebi.eva.evaseqcol.service.SeqColService;
 
 import java.io.IOException;
@@ -54,10 +55,8 @@ public class AdminController {
             example = "GCA_000146045.2",
             required = true) @PathVariable String asmAccession) {
         try {
-            List<String> level0Digests = seqColService.fetchAndInsertAllSeqColByAssemblyAccession(asmAccession);
-            return new ResponseEntity<>(
-                    "Successfully inserted seqCol object(s) for assembly accession " + asmAccession + "\nSeqCol digests=" + level0Digests
-                    , HttpStatus.OK);
+            IngestionResultEntity ingestionResult = seqColService.fetchAndInsertAllSeqColByAssemblyAccession(asmAccession);
+            return ResponseEntity.ok(ingestionResult);
         } catch (IncorrectAccessionException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColExtendedDataEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColExtendedDataEntity.java
@@ -49,6 +49,7 @@ public class SeqColExtendedDataEntity<T> {
     @Transient
     // This is needed when constructing multiple seqCol objects from the datasource to
     // identify the naming convention used for the sequences.
+    // Note: This will probably be required by the namesAttributeList and might be null for the others
     private SeqColEntity.NamingConvention namingConvention;
 
     public enum AttributeType {

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/AssemblyAlreadyIngestedException.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/AssemblyAlreadyIngestedException.java
@@ -2,6 +2,6 @@ package uk.ac.ebi.eva.evaseqcol.exception;
 
 public class AssemblyAlreadyIngestedException extends RuntimeException{
     public AssemblyAlreadyIngestedException(String assemblyAccession) {
-        super("Seqcol objects for assembly " + assemblyAccession + " has been already ingested");
+        super("Seqcol objects for assembly " + assemblyAccession + " have already been ingested");
     }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/AssemblyAlreadyIngestedException.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/AssemblyAlreadyIngestedException.java
@@ -1,0 +1,7 @@
+package uk.ac.ebi.eva.evaseqcol.exception;
+
+public class AssemblyAlreadyIngestedException extends RuntimeException{
+    public AssemblyAlreadyIngestedException(String assemblyAccession) {
+        super("Seqcol objects for assembly " + assemblyAccession + " has been already ingested");
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/model/IngestionResultEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/model/IngestionResultEntity.java
@@ -1,0 +1,38 @@
+package uk.ac.ebi.eva.evaseqcol.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This Entity will hold the information that should be returned
+ * upon ingestion of seqcol objects (given the assembly accession)*/
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class IngestionResultEntity {
+
+    @JsonProperty("assembly_accession")
+    private String assemblyAccession;
+    @JsonProperty("numberOfInsertedSeqcols")
+    private Integer numberOfInsertedSeqcols = 0;
+    @JsonProperty("inserted_seqcols")
+    private List<InsertedSeqColEntity> insertedSeqcols = new ArrayList<>();
+    @JsonProperty("error_message")
+    private String errorMessage = null;
+
+
+    public void addInsertedSeqCol(InsertedSeqColEntity insertedSeqCol) {
+        this.insertedSeqcols.add(insertedSeqCol);
+    }
+
+    /**
+     * Increment the numberOfInsertedSeqcols by one*/
+    public void incrementNumberOfInsertedSeqCols() {
+        this.numberOfInsertedSeqcols += 1;
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/model/IngestionResultEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/model/IngestionResultEntity.java
@@ -18,7 +18,7 @@ public class IngestionResultEntity {
 
     @JsonProperty("assembly_accession")
     private String assemblyAccession;
-    @JsonProperty("numberOfInsertedSeqcols")
+    @JsonProperty("num_inserted_seqcols")
     private Integer numberOfInsertedSeqcols = 0;
     @JsonProperty("inserted_seqcols")
     private List<InsertedSeqColEntity> insertedSeqcols = new ArrayList<>();

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/model/InsertedSeqColEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/model/InsertedSeqColEntity.java
@@ -1,0 +1,19 @@
+package uk.ac.ebi.eva.evaseqcol.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * This entity will hold minimal seqcol information that will be returned
+ * to the user upon ingestion*/
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InsertedSeqColEntity {
+
+    private String digest; // Level 0 digest
+    @JsonProperty("naming_convention")
+    private String namingConvention;
+}

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/AdminControllerIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/AdminControllerIntegrationTest.java
@@ -1,10 +1,11 @@
 package uk.ac.ebi.eva.evaseqcol.controller;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.support.BasicAuthenticationInterceptor;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,15 +26,18 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
-import uk.ac.ebi.eva.evaseqcol.exception.AssemblyAlreadyIngestedException;
 import uk.ac.ebi.eva.evaseqcol.service.SeqColService;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Testcontainers
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class AdminControllerIntegrationTest {
 
     @LocalServerPort
@@ -82,10 +87,11 @@ public class AdminControllerIntegrationTest {
 
     @AfterEach
     void tearDown() {
-        seqColService.removeAllSeqCol();
+        seqColService.removeAllSeqCol(); // TODO Fix: This operation is rolled back for some reason @see 'https://www.baeldung.com/hibernate-initialize-proxy-exception' (might help)
     }
 
     @Test
+    @Order(2)
     @Transactional
     /**
      * Ingest all possible seqCol objects given the assembly accession*/
@@ -103,6 +109,7 @@ public class AdminControllerIntegrationTest {
     }
 
     @Test
+    @Order(1)
     /**
      * Testing the response for the ingestion endpoint for
      * different kind of ingestion cases:


### PR DESCRIPTION
## Description
Currently the **ingestion endpoint**'s result object is a simple string, which is not very standardized as an API's return type. So in this PR we're trying to make a more standardized return type/format of the ingestion endpoint.
Fixes #72 

## Proposed return object
Our proposed return object of the ingestion endpoint is a JSON object containing some information about the what was ingested, and any errors if existed. Here's an example of how the proposed object will look like:
```json
{
    "assembly_accession": "GCA_000146045.2",
    "num_inserted_seqcols": 2,
    "inserted_seqcols": [
        {
            "digest": "3mTg0tAA3PS-R1TzelLVWJ2ilUzoWfVq",
            "naming_convention": "GENBANK"
        },
        {
            "digest": "rkTW1yZ0e22IN8K-0frqoGOMT8dynNyE",
            "naming_convention": "UCSC"
        }
    ],
    "error_message": null
}
```
## Some examples of the ingestion return type
1. Trying to ingest new seqcol objects given a **valid assembly accession**:
    a. Endpoint: `/eva/webservices/seqcol/admin/seqcols/GCA_000146045.2`
    b. Result:
```json
{
    "assembly_accession": "GCA_000146045.2",
    "num_inserted_seqcols": 2,
    "inserted_seqcols": [
        {
            "digest": "3mTg0tAA3PS-R1TzelLVWJ2ilUzoWfVq",
            "naming_convention": "GENBANK"
        },
        {
            "digest": "rkTW1yZ0e22IN8K-0frqoGOMT8dynNyE",
            "naming_convention": "UCSC"
        }
    ],
    "error_message": null
}
```

2. Trying to ingest new seqcol objects given an **unvalid assembly accession**:
    a. endpoint: `/eva/webservices/seqcol/admin/seqcols/GCA_000146045.23`
    b. Result:
```json
{
    "assembly_accession": "GCA_000146045.23",
    "num_inserted_seqcols": 0,
    "inserted_seqcols": [],
    "error_message": "No seqCol data corresponding to assemblyAccession GCA_000146045.23 could be found on NCBI datasource"
}
```

3. Trying to ingest **already existing seqcol objects** given a valid assembly accession:
    a. endpoint: `/eva/webservices/seqcol/admin/seqcols/GCA_000146045.2`
    b. Result:
```json
{
    "assembly_accession": "GCA_000146045.2",
    "num_inserted_seqcols": 0,
    "inserted_seqcols": [],
    "error_message": null
}
```

## Further Discussion
This is only a proposal of the ingestion endpoint's result object, however I believe we have to make more discussion about it and especially with the **refget** team, to include the change in the spec first.
@tcezard what do you think ?