### PR TITLE
updated the swagger page's endpoints' names to more meaningful names

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,7 @@ import java.util.List;
 
 @RequestMapping("/admin")
 @RestController
+@Tag(name = "Admin endpoints")
 public class AdminController {
 
     private SeqColService seqColService;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,7 @@ import java.util.TreeMap;
 
 @RestController
 @RequestMapping("/comparison")
+@Tag(name = "Comparison endpoints")
 public class SeqColComparisonController {
 
     private SeqColService seqColService;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
@@ -24,7 +24,7 @@ import java.util.TreeMap;
 
 @RestController
 @RequestMapping("/comparison")
-@Tag(name = "Secqol endpoints")
+@Tag(name = "Seqcol endpoints")
 public class SeqColComparisonController {
 
     private SeqColService seqColService;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColComparisonController.java
@@ -24,7 +24,7 @@ import java.util.TreeMap;
 
 @RestController
 @RequestMapping("/comparison")
-@Tag(name = "Comparison endpoints")
+@Tag(name = "Secqol endpoints")
 public class SeqColComparisonController {
 
     private SeqColService seqColService;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,7 @@ import java.util.Optional;
 
 @RestController
 @RequestMapping("/")
+@Tag(name = "Secqol endpoint")
 public class SeqColController {
 
     private SeqColService seqColService;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 @RestController
 @RequestMapping("/")
-@Tag(name = "Secqol endpoint")
+@Tag(name = "Secqol endpoints")
 public class SeqColController {
 
     private SeqColService seqColService;

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/seqcol/SeqColController.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 @RestController
 @RequestMapping("/")
-@Tag(name = "Secqol endpoints")
+@Tag(name = "Seqcol endpoints")
 public class SeqColController {
 
     private SeqColService seqColService;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,5 +39,5 @@ springdoc.swagger-ui.path=/seqcol-documentation
 springdoc.api-docs.path=/seqcol-api-docs
 
 springdoc.packages-to-scan=uk.ac.ebi.eva.evaseqcol.controller
-springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.operationsSorter=alpha
 springdoc.swagger-ui.tagsSorter=alpha


### PR DESCRIPTION
## Description
Currently the endpoints in the swagger page are named the same as the controller name. So we propose to change the endpoint names in the swagger ui to a more meaningful names.
Fixes #76 
## Swagger UI before and after the change
### Before
![Screenshot from 2024-01-22 16-20-10](https://github.com/EBIvariation/eva-seqcol/assets/82417779/d99dc234-3d5a-45bd-bb7e-73dc8ce77276)
### After
![Screenshot from 2024-01-22 16-12-46](https://github.com/EBIvariation/eva-seqcol/assets/82417779/918d9b5b-b803-4e08-834e-6fb62b0b618d)

## Finally
I would really like to hear your feedback on the naming of the endpoints, in order to have the best meaningful names.

