### PR TITLE
added a column 'asm_accession' to the sequence_collection_l1 table

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
@@ -1,6 +1,5 @@
 package uk.ac.ebi.eva.evaseqcol.entities;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Type;
@@ -39,13 +38,13 @@ public class SeqColLevelOneEntity extends SeqColEntity{
     protected NamingConvention namingConvention;
 
     @Column(name = "insdc_accession")
-    private String asm_accession; // The INSDC assembly accession from which the seqcol was created
+    private String asmAccession; // The INSDC assembly accession from which the seqcol was created
 
-    public SeqColLevelOneEntity(String digest, NamingConvention namingConvention, JSONLevelOne jsonLevelOne, String asm_accession){
+    public SeqColLevelOneEntity(String digest, NamingConvention namingConvention, JSONLevelOne jsonLevelOne, String asmAccession){
         super(digest, namingConvention);
         this.seqColLevel1Object = jsonLevelOne;
         this.namingConvention = namingConvention;
-        this.asm_accession = asm_accession;
+        this.asmAccession = asmAccession;
     }
 
     @Override

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
@@ -1,5 +1,6 @@
 package uk.ac.ebi.eva.evaseqcol.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Type;
@@ -37,10 +38,14 @@ public class SeqColLevelOneEntity extends SeqColEntity{
     @Enumerated(EnumType.STRING)
     protected NamingConvention namingConvention;
 
-    public SeqColLevelOneEntity(String digest, NamingConvention namingConvention, JSONLevelOne jsonLevelOne){
+    @Column(name = "insdc_accession")
+    private String asm_accession; // The INSDC assembly accession from which the seqcol was created
+
+    public SeqColLevelOneEntity(String digest, NamingConvention namingConvention, JSONLevelOne jsonLevelOne, String asm_accession){
         super(digest, namingConvention);
         this.seqColLevel1Object = jsonLevelOne;
         this.namingConvention = namingConvention;
+        this.asm_accession = asm_accession;
     }
 
     @Override

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColLevelOneRepository.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColLevelOneRepository.java
@@ -8,6 +8,7 @@ import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 @Repository
 public interface SeqColLevelOneRepository extends JpaRepository<SeqColLevelOneEntity, String> {
     SeqColLevelOneEntity findSeqColLevelOneEntityByDigest(String digest);
+    boolean existsByAsmAccession(String asm_accession);
 
     long countSeqColLevelOneEntitiesByDigest(String digest);
 

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -65,8 +65,9 @@ public class SeqColLevelOneService {
      * hold names, lengths and sequences objects*/
     public SeqColLevelOneEntity constructSeqColLevelOne(List<SeqColExtendedDataEntity<List<String>>> stringListExtendedDataEntities,
                                                         List<SeqColExtendedDataEntity<List<Integer>>> integerListExtendedDataEntities,
-                                                        SeqColEntity.NamingConvention convention) throws IOException {
+                                                        SeqColEntity.NamingConvention convention, String asm_accession) throws IOException {
         SeqColLevelOneEntity levelOneEntity = new SeqColLevelOneEntity();
+        levelOneEntity.setAsm_accession(asm_accession);
         JSONLevelOne jsonLevelOne = new JSONLevelOne();
 
         // Looping over List<String> types
@@ -106,7 +107,8 @@ public class SeqColLevelOneService {
     /**
      * Construct a Level 1 seqCol out of a Level 2 seqCol*/
     public SeqColLevelOneEntity constructSeqColLevelOne(
-            SeqColLevelTwoEntity levelTwoEntity, SeqColEntity.NamingConvention convention) throws IOException {
+            SeqColLevelTwoEntity levelTwoEntity, SeqColEntity.NamingConvention convention, String asm_accession)
+            throws IOException {
         DigestCalculator digestCalculator = new DigestCalculator();
         JSONExtData<List<String>> sequencesExtData = new JSONStringListExtData(levelTwoEntity.getSequences());
         JSONExtData<List<Integer>> lengthsExtData = new JSONIntegerListExtData(levelTwoEntity.getLengths());
@@ -151,7 +153,7 @@ public class SeqColLevelOneService {
                 lengthsExtEntity
         );
 
-        return constructSeqColLevelOne(stringListExtendedDataEntities,integerListExtendedDataEntities, convention);
+        return constructSeqColLevelOne(stringListExtendedDataEntities,integerListExtendedDataEntities, convention, asm_accession);
     }
 
     /**

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneService.java
@@ -45,6 +45,12 @@ public class SeqColLevelOneService {
         }
     }
 
+    /**
+     * Check whether the given asm_accession exists in the database (in the sequence_collection_level1)*/
+    public boolean isAsmAccessionExists(String asm_accession) {
+        return repository.existsByAsmAccession(asm_accession);
+    }
+
     public void removeSeqColLevelOneByDigest(String digest) {
         repository.removeSeqColLevelOneEntityByDigest(digest);
     }
@@ -67,7 +73,7 @@ public class SeqColLevelOneService {
                                                         List<SeqColExtendedDataEntity<List<Integer>>> integerListExtendedDataEntities,
                                                         SeqColEntity.NamingConvention convention, String asm_accession) throws IOException {
         SeqColLevelOneEntity levelOneEntity = new SeqColLevelOneEntity();
-        levelOneEntity.setAsm_accession(asm_accession);
+        levelOneEntity.setAsmAccession(asm_accession);
         JSONLevelOne jsonLevelOne = new JSONLevelOne();
 
         // Looping over List<String> types

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -198,8 +198,8 @@ public class SeqColService {
 
             // Constructing seqCol Level One object
             SeqColLevelOneEntity levelOneEntity = levelOneService.constructSeqColLevelOne(
-                    seqColStringListExtDataEntities, seqColIntegerListExtDataEntities, extendedNamesEntity.getNamingConvention()
-                    );
+                    seqColStringListExtDataEntities, seqColIntegerListExtDataEntities, extendedNamesEntity.getNamingConvention(),
+                    assemblyAccession);
 
             try {
                 Optional<String> seqColDigest = insertSeqColL1AndL2( // TODO: Check for possible self invocation problem

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/SeqColService.java
@@ -162,6 +162,10 @@ public class SeqColService {
     public IngestionResultEntity fetchAndInsertAllSeqColByAssemblyAccession(
             String assemblyAccession) throws IOException, DuplicateSeqColException, AssemblyNotFoundException,
             AssemblyAlreadyIngestedException{
+        if (levelOneService.isAsmAccessionExists(assemblyAccession)) {
+            logger.warn("Seqcol objects for assembly " + assemblyAccession + " has been already ingested");
+            throw new AssemblyAlreadyIngestedException(assemblyAccession);
+        }
         Optional<Map<String, Object>> seqColDataMap = ncbiSeqColDataSource
                 .getAllPossibleSeqColExtendedData(assemblyAccession);
         if (!seqColDataMap.isPresent()) {
@@ -218,12 +222,7 @@ public class SeqColService {
                 " already exists. Skipping.");
             }
         }
-        if (ingestionResultEntity.getNumberOfInsertedSeqcols() == 0) {
-            logger.warn("Seqcol objects for assembly " + assemblyAccession + " has been already ingested");
-            throw new AssemblyAlreadyIngestedException(assemblyAccession);
-        } else {
-            return ingestionResultEntity;
-        }
+        return ingestionResultEntity;
 
     }
 

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/AdminControllerIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/AdminControllerIntegrationTest.java
@@ -14,7 +14,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.support.BasicAuthenticationInterceptor;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Transactional;
@@ -106,7 +105,7 @@ public class AdminControllerIntegrationTest {
         assertTrue(levelTwoEntity.isPresent());
         assertEquals(insertedSeqColDigest,levelOneEntity.get().getDigest());
         assertNotNull(levelTwoEntity.get().getLengths());
-        assertEquals(ASM_ACCESSION, levelOneEntity.get().getAsm_accession());
+        assertEquals(ASM_ACCESSION, levelOneEntity.get().getAsmAccession());
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/AdminControllerIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/controller/AdminControllerIntegrationTest.java
@@ -106,6 +106,7 @@ public class AdminControllerIntegrationTest {
         assertTrue(levelTwoEntity.isPresent());
         assertEquals(insertedSeqColDigest,levelOneEntity.get().getDigest());
         assertNotNull(levelTwoEntity.get().getLengths());
+        assertEquals(ASM_ACCESSION, levelOneEntity.get().getAsm_accession());
     }
 
     @Test

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/io/SeqColWriter.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/io/SeqColWriter.java
@@ -146,7 +146,8 @@ public class SeqColWriter {
         extendedIntegerListDataEntitiesUcsc =
                 (List<SeqColExtendedDataEntity<List<Integer>>>) ucscExtendedDataMap.get("integerListExtDataList");
         levelOneEntityUcsc = levelOneService.constructSeqColLevelOne(
-                extendedStringListDataEntitiesUcsc, extendedIntegerListDataEntitiesUcsc, SeqColEntity.NamingConvention.UCSC);
+                extendedStringListDataEntitiesUcsc, extendedIntegerListDataEntitiesUcsc, SeqColEntity.NamingConvention.UCSC,
+                assemblyEntity.getInsdcAccession());
         Optional<String> resultDigestUcsc = seqColService.addFullSequenceCollection(
                 levelOneEntityUcsc, extendedStringListDataEntitiesUcsc, extendedIntegerListDataEntitiesUcsc);
         if (resultDigestUcsc.isPresent()) {
@@ -163,7 +164,8 @@ public class SeqColWriter {
         extendedIntegerListDataEntitiesGenbank = (List<SeqColExtendedDataEntity<List<Integer>>>) genbankExtendedDataMap.get("integerListExtDataList");
 
         levelOneEntityGenbank = levelOneService.constructSeqColLevelOne(
-                extendedStringListDataEntitiesGenbank, extendedIntegerListDataEntitiesGenbank, SeqColEntity.NamingConvention.GENBANK);
+                extendedStringListDataEntitiesGenbank, extendedIntegerListDataEntitiesGenbank, SeqColEntity.NamingConvention.GENBANK,
+                assemblyEntity.getInsdcAccession());
         Optional<String> resultDigestGenbank = seqColService.addFullSequenceCollection(
                 levelOneEntityGenbank, extendedStringListDataEntitiesGenbank, extendedIntegerListDataEntitiesGenbank);
         if (resultDigestGenbank.isPresent()) {

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneServiceTest.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/service/SeqColLevelOneServiceTest.java
@@ -82,10 +82,12 @@ class SeqColLevelOneServiceTest {
         List<SeqColExtendedDataEntity<List<Integer>>> integerListExtDataList =
                 (List<SeqColExtendedDataEntity<List<Integer>>>) extendedDataMapGenbank.get("integerListExtDataList");
         SeqColLevelOneEntity levelOneEntity = levelOneService.constructSeqColLevelOne(
-                stringListExtDataList, integerListExtDataList, SeqColEntity.NamingConvention.GENBANK);
+                stringListExtDataList, integerListExtDataList, SeqColEntity.NamingConvention.GENBANK, assemblyEntity.getInsdcAccession());
         SeqColLevelTwoEntity levelTwoEntity = levelTwoService.
                 constructSeqColL2(levelOneEntity.getDigest(), stringListExtDataList, integerListExtDataList);
-        SeqColLevelOneEntity constructedEntity = levelOneService.constructSeqColLevelOne(levelTwoEntity, SeqColEntity.NamingConvention.GENBANK);
+        SeqColLevelOneEntity constructedEntity = levelOneService.constructSeqColLevelOne(levelTwoEntity,
+                                                                                         SeqColEntity.NamingConvention.GENBANK,
+                                                                                         assemblyEntity.getInsdcAccession());
         assertNotNull(constructedEntity);
         assertNotNull(constructedEntity.getSeqColLevel1Object().getSequences());
     }
@@ -100,7 +102,7 @@ class SeqColLevelOneServiceTest {
         List<SeqColExtendedDataEntity<List<Integer>>> integerListExtDataList =
                 (List<SeqColExtendedDataEntity<List<Integer>>>) extendedDataMapGenbank.get("integerListExtDataList");
         SeqColLevelOneEntity levelOneEntity = levelOneService.constructSeqColLevelOne(
-                stringListExtDataList, integerListExtDataList, SeqColEntity.NamingConvention.GENBANK);
+                stringListExtDataList, integerListExtDataList, SeqColEntity.NamingConvention.GENBANK, assemblyEntity.getInsdcAccession());
         Optional<SeqColLevelOneEntity> savedEntity = levelOneService.addSequenceCollectionL1(levelOneEntity);
         assertTrue(savedEntity.isPresent());
         System.out.println(savedEntity.get());


### PR DESCRIPTION
## Description
Currently, the API doesn't store the **assembly accession** value that corresponds to each inserted seqcol object. Which is an important meta data that can be useful.
Fixes #13 

## Solution design
We propose to add a new attribute `asm_accession` in the `SeqColLevelOneEntity` class (and hence a new column in the `sequence_collections_l1` table). 

So the resulting table will be the following (we ignored the display of the jsonLevelOneObject):
![Screenshot from 2024-02-05 17-27-08](https://github.com/EBIvariation/eva-seqcol/assets/82417779/7d54d79f-3b96-4ed7-970f-159d9d09c33d)
And of course, the `asm_accession` will not be returned in level 1 nor in level 2. (we may have a further discussion about this)

Now the API will check for the existence of an asm_accession before proceeding with the ingestion process, this will help avoid all the extra work of downloading data, constructing the objects and then checking.

**However**, we should consider checking the case where not all seqcol objects that correspond to a specific asm_accession are inserted in the database, in that case we should insert them. (<ins>I think this case is very much less likely to happen</ins>)
## Further discussion
I think we can discuss the naming of `asm_accession`, because it might make sense to call it `insdc_accession` ?