### PR TITLE
replaced the hyphen with underscore for the level one

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/utils/JSONLevelOne.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/utils/JSONLevelOne.java
@@ -12,11 +12,11 @@ import java.io.Serializable;
 @NoArgsConstructor
 public class JSONLevelOne implements Serializable {
     private String sequences;
-    @JsonProperty("md5-sequences") // Revert back
+    @JsonProperty("md5_sequences")
     private String md5DigestsOfSequences;
     private String names;
     private String lengths;
-    @JsonProperty("sorted-name-length-pairs") // Revert back
+    @JsonProperty("sorted_name_length_pairs")
     private String sortedNameLengthPairs;
 
     public JSONLevelOne setSequences(String sequences) {


### PR DESCRIPTION
Just figured out that we're still using **hyphens** instead of **underscores** for the level one objects
