### PR TITLE
Added a meta data table - one-to-one relationship approach

### DIFF
--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/controller/admin/AdminController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.ac.ebi.eva.evaseqcol.exception.AssemblyAlreadyIngestedException;
 import uk.ac.ebi.eva.evaseqcol.exception.AssemblyNotFoundException;
 import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColException;
+import uk.ac.ebi.eva.evaseqcol.exception.DuplicateSeqColWithDifferentMetadata;
 import uk.ac.ebi.eva.evaseqcol.exception.IncorrectAccessionException;
 import uk.ac.ebi.eva.evaseqcol.model.IngestionResultEntity;
 import uk.ac.ebi.eva.evaseqcol.service.SeqColService;
@@ -71,6 +72,8 @@ public class AdminController {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (DuplicateSeqColException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.CONFLICT);
+        } catch (DuplicateSeqColWithDifferentMetadata e) {
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.CREATED); // TODO: review this response
         } catch (AssemblyNotFoundException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.NOT_FOUND);
         } catch (AssemblyAlreadyIngestedException e) {

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColEntity.java
@@ -17,8 +17,6 @@ public abstract class SeqColEntity {
 
     protected String digest; // The level 0 digest
 
-    protected NamingConvention namingConvention;
-
 
     public enum NamingConvention {
         ENA, GENBANK, UCSC, TEST

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelOneEntity.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.Type;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
 
 import javax.persistence.Basic;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -14,13 +15,15 @@ import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinColumns;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Entity
 @NoArgsConstructor
 @Data
 @Table(name = "sequence_collections_L1")
-@IdClass(SeqColId.class)
 public class SeqColLevelOneEntity extends SeqColEntity{
 
     @Id
@@ -32,15 +35,16 @@ public class SeqColLevelOneEntity extends SeqColEntity{
     @Basic(fetch = FetchType.LAZY)
     private JSONLevelOne seqColLevel1Object;
 
-    @Id
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    protected NamingConvention namingConvention;
-
-    public SeqColLevelOneEntity(String digest, NamingConvention namingConvention, JSONLevelOne jsonLevelOne){
-        super(digest, namingConvention);
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumns({
+            @JoinColumn(name = "seqcol_digest", referencedColumnName = "seqcol_digest"),
+            @JoinColumn(name = "source_id", referencedColumnName = "source_identifier")
+    })
+    private SeqColMetadata metadata;
+    public SeqColLevelOneEntity(String digest, JSONLevelOne jsonLevelOne, SeqColMetadata metadata){
+        super(digest);
         this.seqColLevel1Object = jsonLevelOne;
-        this.namingConvention = namingConvention;
+        this.metadata = metadata;
     }
 
     @Override

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelTwoEntity.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColLevelTwoEntity.java
@@ -24,9 +24,4 @@ public class SeqColLevelTwoEntity extends SeqColEntity{
         this.digest = digest;
         return this;
     }
-
-    public SeqColLevelTwoEntity setNamingConvention(NamingConvention convention) {
-        this.namingConvention = convention;
-        return this;
-    }
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColMetadata.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColMetadata.java
@@ -1,0 +1,67 @@
+package uk.ac.ebi.eva.evaseqcol.entities;
+
+import lombok.Data;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
+
+@Entity
+@IdClass(SeqColMetadataId.class)
+@Table(name = "seqcol_md")
+@Data
+public class SeqColMetadata {
+
+    @Id
+    @Column(name = "seqcol_digest")
+    private String seqColDigest;
+
+    @Id
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_identifier")
+    private SourceIdentifier sourceIdentifier;
+
+    private String sourceUrl;
+
+    @Enumerated(EnumType.STRING)
+    private SeqColEntity.NamingConvention namingConvention;
+
+    @Column(insertable = false, updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date timestamp;
+
+    @OneToOne(mappedBy = "metadata")
+    private SeqColLevelOneEntity seqColLevelOne;
+
+    public enum SourceIdentifier {
+        Insdc
+    }
+
+    public SeqColMetadata setSeqColDigest(String digest) {
+        this.seqColDigest = digest;
+        return this;
+    }
+
+    public SeqColMetadata setSourceIdentifier(SourceIdentifier sourceIdentifier) {
+        this.sourceIdentifier = sourceIdentifier;
+        return this;
+    }
+
+    public SeqColMetadata setSourceUrl(String sourceUrl) {
+        this.sourceUrl = sourceUrl;
+        return this;
+    }
+
+    public SeqColMetadata setNamingConvention(SeqColEntity.NamingConvention namingConvention) {
+        this.namingConvention = namingConvention;
+        return this;
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColMetadataId.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/entities/SeqColMetadataId.java
@@ -1,0 +1,22 @@
+package uk.ac.ebi.eva.evaseqcol.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+
+@EqualsAndHashCode
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+public class SeqColMetadataId implements Serializable {
+
+    @NotNull
+    private String seqColDigest;
+    @NotNull
+    private SeqColMetadata.SourceIdentifier sourceIdentifier; // Eg: INSDC, UCSC, GENBANK, etc..
+
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/DuplicateSeqColWithDifferentMetadata.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/exception/DuplicateSeqColWithDifferentMetadata.java
@@ -1,0 +1,8 @@
+package uk.ac.ebi.eva.evaseqcol.exception;
+
+public class DuplicateSeqColWithDifferentMetadata extends RuntimeException{
+    
+    public DuplicateSeqColWithDifferentMetadata(String digest) {
+        super("A similar seqCol already exists with digest " + digest + " but with different metadata");
+    }
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/MetadataRepository.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/MetadataRepository.java
@@ -1,0 +1,15 @@
+package uk.ac.ebi.eva.evaseqcol.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColMetadata;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColMetadataId;
+
+import java.util.List;
+
+@Repository
+public interface MetadataRepository extends JpaRepository<SeqColMetadata, SeqColMetadataId> {
+
+    List<SeqColMetadata> findAllBySeqColDigest(String digest);
+}

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColLevelOneRepository.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/repo/SeqColLevelOneRepository.java
@@ -14,4 +14,5 @@ public interface SeqColLevelOneRepository extends JpaRepository<SeqColLevelOneEn
     void removeSeqColLevelOneEntityByDigest(String digest);
 
     void deleteAll();
+
 }

--- a/src/main/java/uk/ac/ebi/eva/evaseqcol/service/MetadataService.java
+++ b/src/main/java/uk/ac/ebi/eva/evaseqcol/service/MetadataService.java
@@ -1,0 +1,35 @@
+package uk.ac.ebi.eva.evaseqcol.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColMetadata;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColMetadataId;
+import uk.ac.ebi.eva.evaseqcol.repo.MetadataRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class MetadataService {
+
+    @Autowired
+    private MetadataRepository repository;
+
+    public Optional<SeqColMetadata> addMetadata(SeqColMetadata metadata) {
+        if (repository.existsById(new SeqColMetadataId(metadata.getSeqColDigest(), metadata.getSourceIdentifier()))){
+            return Optional.empty();
+        }
+        return Optional.of(
+                repository.save(metadata)
+        );
+    }
+
+    /**
+     * Return the list of all metadata entries for the seqCol object with the given digest*/
+    public Optional<List<SeqColMetadata>> getAllMetadataForSeqColByDigest(String seqColDigest) {
+        return Optional.of(
+                repository.findAllBySeqColDigest(seqColDigest)
+        );
+    }
+}

--- a/src/test/java/uk/ac/ebi/eva/evaseqcol/io/SeqColGenerator.java
+++ b/src/test/java/uk/ac/ebi/eva/evaseqcol/io/SeqColGenerator.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelOneEntity;
 import uk.ac.ebi.eva.evaseqcol.entities.SeqColLevelTwoEntity;
+import uk.ac.ebi.eva.evaseqcol.entities.SeqColMetadata;
 import uk.ac.ebi.eva.evaseqcol.utils.JSONLevelOne;
 
 import java.util.Arrays;
@@ -16,24 +17,27 @@ public class SeqColGenerator {
 
     /**
      * Return an example (might not be real) of a seqCol object level 1
-     * The naming convention is set to GENBANK as a random choice*/
+     * The naming convention is set to GENBANK as a random choice
+     * and source identifier is set Insdc*/
     public SeqColLevelOneEntity generateLevelOneEntity() {
         SeqColLevelOneEntity levelOneEntity = new SeqColLevelOneEntity();
         JSONLevelOne jsonLevelOne = new JSONLevelOne();
+        SeqColMetadata metadata = new SeqColMetadata()
+                .setNamingConvention(SeqColEntity.NamingConvention.GENBANK)
+                .setSeqColDigest("PgQMkKm2A8I9GVW7hJWcJ3erxuaMbHpD")
+                .setSourceIdentifier(SeqColMetadata.SourceIdentifier.Insdc);
         jsonLevelOne.setNames("mfxUkK3J5y7BGVW7hJWcJ3erxuaMX6xm");
         jsonLevelOne.setSequences("dda3Kzi1Wkm2A8I99WietU1R8J4PL-D6");
         jsonLevelOne.setLengths("Ms_ixPgQMJaM54dVntLWeovXSO7ljvZh");
         jsonLevelOne.setMd5DigestsOfSequences("_6iaYtcWw4TZaowlL7_64Wu9mbHpDUw4");
         jsonLevelOne.setSortedNameLengthPairs("QFuKs5Hh8uQwwUtnRxIf8W3zeJoFOp8Z");
         levelOneEntity.setSeqColLevel1Object(jsonLevelOne);
-        levelOneEntity.setDigest("3mTg0tAA3PS-R1TzelLVWJ2ilUzoWfVq");
-        levelOneEntity.setNamingConvention(SeqColEntity.NamingConvention.GENBANK);
+        levelOneEntity.setMetadata(metadata);
         return levelOneEntity;
     }
 
     /**
      * Return an example (might not be real) of a seqCol object level 2
-     * The naming convention is set to GENBANK as a random choice
      * */
     public SeqColLevelTwoEntity generateLevelTwoEntity() {
         SeqColLevelTwoEntity levelTwoEntity = new SeqColLevelTwoEntity();
@@ -128,7 +132,6 @@ public class SeqColGenerator {
                 "YfHZgnpuJm4SN3RN4XL1VWWWZwTXtqw5"
         ));
         levelTwoEntity.setDigest("3mTg0tAA3PS-R1TzelLVWJ2ilUzoWfVq");
-        levelTwoEntity.setNamingConvention(SeqColEntity.NamingConvention.GENBANK);
         return levelTwoEntity;
     }
 }


### PR DESCRIPTION
## Description
In this PR we're attempting to separate the seqcol meta-data from the seqcol entities, by storing them into a separate table.
Fixes #13 
## Changes made
- Created a separate `SeqColMetadata` entity
- Made the primary key of the this entity composite of `seqcol_digest` & `naming_convention`:
  - I think this should be discussed further to decide whether we should be adding more columns to the primary key, or we should even consider changing the relationship to a `one-to-many` relationship. It  depends on the possible different shapes that a seqcol can take in the future.


Here's the new Java model:

```mermaid
classDiagram
    class SeqColLevelOneEntity
    SeqColLevelOneEntity: - digest
    SeqColLevelOneEntity: - seqColLevel1Object
    class SeqColMetadata
    SeqColMetadata: - seqColDigest
    SeqColMetadata: - sourceIdentifier
    SeqColMetadata: - sourceUrl
    SeqColMetadata: - namingConvention
    SeqColMetadata: - timestamp
    SeqColLevelOneEntity --> SeqColMetadata
```
 And a sample content of the `seqcol_md` table:
![Screenshot from 2024-03-22 16-50-20](https://github.com/EBIvariation/eva-seqcol/assets/82417779/e75bd0e1-ce37-4f04-b14d-3d659ee8c25c)

## Changes to make
Each change of the following can be set in a different issue
- [ ] Change the return type of the ingestion endpoint in case we have duplicate seqcol with different meta-data.
- [ ] Update the ingestion process by including the metadata object as parameter of the construction methods.
- [ ] Complete the logic for the `source_url` & `timestamp`
- [ ] Adding some test cases to cover all possible scenarios.
 
## Discussion
I'm not sure to what extent this approach can cover all the possible scenarios of seqcol meta-data content, and I think making a `one-to-many` relationship might be efficient in case we had to make all columns of the `seqcol_md` table primary keys, which means:
- we can have different seqcol with same `digest` but with different `source identifiers` &
- we can have different seqcol with same `digest` and `naming convention` but with different` source identifier` &
- we can have different seqcol with same `digest`, `naming convention` and `source identifier` but with different `source_url` &
- ... 

**NOTE:** The current `seqcol_md` table have both `seqcol_digest` & `naming_convention` as composite primary key, which means that **we can't find two seqcol objects with same digest and same naming_convention**. Can we get such case ??